### PR TITLE
feat: add skills registry browser with multi-agent install

### DIFF
--- a/Chops.xcodeproj/project.pbxproj
+++ b/Chops.xcodeproj/project.pbxproj
@@ -19,9 +19,12 @@
 		7A17C99C5EFAE3AA9E788D50 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AFE1AF02B0F8057791C2A9 /* Collection.swift */; };
 		7EC6156934D559226BC78859 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA102A49ACFB23BC15794F8 /* CollectionListView.swift */; };
 		7FD1DE6640F9339D5E97E09A /* MDCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4F680B33C74A38FCF5ADD5 /* MDCParser.swift */; };
+		846B58F3B105D1734DC6FA75 /* SkillRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC9D3E83D8640CC258CF361 /* SkillRegistry.swift */; };
 		87A469B631CC80C89B14B1C7 /* SkillMetadataBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C812515FD8DC222B89745F2 /* SkillMetadataBar.swift */; };
 		95163AEB7980654C901EC693 /* Skill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D6ED655F951177D2152351 /* Skill.swift */; };
+		98434D3DDFEEC7239F6F7B79 /* RegistrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCD6C2A8BE68F553A9CA392 /* RegistrySheet.swift */; };
 		99EE8F6124FE91AC9576D6FD /* FileWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */; };
+		B5B95B9DA63A734F25470FF5 /* SchemaVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F8AA042D5D8A9F92F35CA3 /* SchemaVersions.swift */; };
 		BD584933CCE2B650345C4CF1 /* ToolSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5487D9027B97F7E9EE9A1F4A /* ToolSource.swift */; };
 		C30BEAE03E54BD36F257A925 /* ToolFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5774429CCE83C2AFBE046C /* ToolFilterView.swift */; };
 		C6CFF37CC0B155E8846344A4 /* ChopsIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 04C3C644B72DD508A7CBC403 /* ChopsIcon.icon */; };
@@ -32,6 +35,7 @@
 		E98F7490B18A194F82ED2C0E /* SkillListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA64A368BBF950CD36C4F495 /* SkillListView.swift */; };
 		F98B1E8579B139FD2A801650 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC47BDE92105F4736B379F /* SearchService.swift */; };
 		FB295303DD30AED03290C726 /* SkillEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B4DB87833D5160A11E39C9 /* SkillEditorView.swift */; };
+		FD8D2544AE423F4AB2843C0F /* AgentTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907E59B064AB8366B60BF611 /* AgentTarget.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,12 +53,16 @@
 		5487D9027B97F7E9EE9A1F4A /* ToolSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSource.swift; sourceTree = "<group>"; };
 		60E0F71982C4AF0045962380 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7C77C5B30E6C885B39444E5B /* FrontmatterParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterParser.swift; sourceTree = "<group>"; };
+		7FCD6C2A8BE68F553A9CA392 /* RegistrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrySheet.swift; sourceTree = "<group>"; };
 		7FFC47BDE92105F4736B379F /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		8C812515FD8DC222B89745F2 /* SkillMetadataBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillMetadataBar.swift; sourceTree = "<group>"; };
+		907E59B064AB8366B60BF611 /* AgentTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTarget.swift; sourceTree = "<group>"; };
 		9A5774429CCE83C2AFBE046C /* ToolFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolFilterView.swift; sourceTree = "<group>"; };
+		9FC9D3E83D8640CC258CF361 /* SkillRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillRegistry.swift; sourceTree = "<group>"; };
 		A7B6AE242CAD6A285DD57079 /* ToolBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBadge.swift; sourceTree = "<group>"; };
 		A924245DDDA4C6A59BE15567 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		AA64A368BBF950CD36C4F495 /* SkillListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillListView.swift; sourceTree = "<group>"; };
+		B1F8AA042D5D8A9F92F35CA3 /* SchemaVersions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaVersions.swift; sourceTree = "<group>"; };
 		B3F5CF5BB1FC8455FDDB004A /* Chops.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chops.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9AFE1AF02B0F8057791C2A9 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWatcher.swift; sourceTree = "<group>"; };
@@ -109,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				F02A00F80E4712872205EA7B /* NewSkillSheet.swift */,
+				7FCD6C2A8BE68F553A9CA392 /* RegistrySheet.swift */,
 				A7B6AE242CAD6A285DD57079 /* ToolBadge.swift */,
 			);
 			path = Shared;
@@ -149,6 +158,7 @@
 				CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */,
 				7FFC47BDE92105F4736B379F /* SearchService.swift */,
 				5155D141EF812A3FE9ADF59C /* SkillParser.swift */,
+				9FC9D3E83D8640CC258CF361 /* SkillRegistry.swift */,
 				E6A5B26D335C1AFB6CDE8207 /* SkillScanner.swift */,
 			);
 			path = Services;
@@ -157,7 +167,9 @@
 		75334DE5CD1545A8E1E63699 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				907E59B064AB8366B60BF611 /* AgentTarget.swift */,
 				C9AFE1AF02B0F8057791C2A9 /* Collection.swift */,
+				B1F8AA042D5D8A9F92F35CA3 /* SchemaVersions.swift */,
 				27D6ED655F951177D2152351 /* Skill.swift */,
 				5487D9027B97F7E9EE9A1F4A /* ToolSource.swift */,
 			);
@@ -274,6 +286,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD8D2544AE423F4AB2843C0F /* AgentTarget.swift in Sources */,
 				25A4FB387DB5BD96DB630C14 /* AppState.swift in Sources */,
 				309B12E0B72A22C9772BBC99 /* ChopsApp.swift in Sources */,
 				7A17C99C5EFAE3AA9E788D50 /* Collection.swift in Sources */,
@@ -283,6 +296,8 @@
 				CBD8FECF1C5A453C8B021665 /* FrontmatterParser.swift in Sources */,
 				7FD1DE6640F9339D5E97E09A /* MDCParser.swift in Sources */,
 				71E92A838AB4D1D6DC6174AF /* NewSkillSheet.swift in Sources */,
+				98434D3DDFEEC7239F6F7B79 /* RegistrySheet.swift in Sources */,
+				B5B95B9DA63A734F25470FF5 /* SchemaVersions.swift in Sources */,
 				F98B1E8579B139FD2A801650 /* SearchService.swift in Sources */,
 				2263A0A3B358FBA099D0086D /* SettingsView.swift in Sources */,
 				CCD92CB102DFA0965D6AFDB5 /* SidebarView.swift in Sources */,
@@ -292,6 +307,7 @@
 				E98F7490B18A194F82ED2C0E /* SkillListView.swift in Sources */,
 				87A469B631CC80C89B14B1C7 /* SkillMetadataBar.swift in Sources */,
 				60A6711BAB0C3B8A3ACBF985 /* SkillParser.swift in Sources */,
+				846B58F3B105D1734DC6FA75 /* SkillRegistry.swift in Sources */,
 				6A8E0927D95BB14C9F377F4E /* SkillScanner.swift in Sources */,
 				53C393C13E30EC439317509F /* ToolBadge.swift in Sources */,
 				C30BEAE03E54BD36F257A925 /* ToolFilterView.swift in Sources */,

--- a/Chops/App/AppState.swift
+++ b/Chops/App/AppState.swift
@@ -6,6 +6,7 @@ final class AppState {
     var selectedSkill: Skill?
     var searchText: String = ""
     var showingNewSkillSheet: Bool = false
+    var showingRegistrySheet: Bool = false
     var sidebarFilter: SidebarFilter = .all
 }
 

--- a/Chops/App/ChopsApp.swift
+++ b/Chops/App/ChopsApp.swift
@@ -16,14 +16,15 @@ struct ChopsApp: App {
     }
 
     var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Skill.self,
-            SkillCollection.self,
-        ])
+        let schema = Schema(versionedSchema: SchemaV1.self)
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
         do {
-            return try ModelContainer(for: schema, configurations: [config])
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: ChopsMigrationPlan.self,
+                configurations: [config]
+            )
         } catch {
             fatalError("Could not create ModelContainer: \(error)")
         }

--- a/Chops/App/ContentView.swift
+++ b/Chops/App/ContentView.swift
@@ -34,13 +34,26 @@ struct ContentView: View {
         .sheet(isPresented: $appState.showingNewSkillSheet) {
             NewSkillSheet()
         }
+        .sheet(isPresented: $appState.showingRegistrySheet) {
+            RegistrySheet()
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    appState.showingNewSkillSheet = true
+                Menu {
+                    Button {
+                        appState.showingNewSkillSheet = true
+                    } label: {
+                        Label("New Skill", systemImage: "plus")
+                    }
+                    Button {
+                        appState.showingRegistrySheet = true
+                    } label: {
+                        Label("Browse Registry", systemImage: "globe")
+                    }
                 } label: {
-                    Label("New Skill", systemImage: "plus")
+                    Label("Add", systemImage: "plus")
                 }
+                .menuIndicator(.hidden)
             }
         }
         .frame(minWidth: 900, minHeight: 500)

--- a/Chops/Models/AgentTarget.swift
+++ b/Chops/Models/AgentTarget.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+struct AgentTarget: Identifiable, Hashable {
+    let id: String
+    let displayName: String
+    let globalSkillsDir: String
+    let skillFileName: String
+
+    /// Paths to check — at least one must exist for the agent to be considered installed.
+    /// These should be files/dirs that the actual tool creates, NOT dirs that `npx skills add` would create.
+    let evidencePaths: [String]
+
+    /// Optional: app bundle name to check in /Applications
+    let appBundleName: String?
+
+    /// Optional: CLI binary name to check in PATH
+    let cliBinaryName: String?
+
+    var isInstalled: Bool {
+        let fm = FileManager.default
+
+        // Check for app bundle
+        if let app = appBundleName, fm.fileExists(atPath: "/Applications/\(app).app") {
+            return true
+        }
+
+        // Check for CLI binary
+        if let cli = cliBinaryName {
+            let searchPaths = [
+                "/usr/local/bin/\(cli)",
+                "/opt/homebrew/bin/\(cli)",
+                "\(fm.homeDirectoryForCurrentUser.path)/.local/bin/\(cli)",
+            ]
+            // Also check nvm paths
+            let nvmDir = "\(fm.homeDirectoryForCurrentUser.path)/.nvm/versions/node"
+            if let nodeDirs = try? fm.contentsOfDirectory(atPath: nvmDir) {
+                for nodeDir in nodeDirs {
+                    let binPath = "\(nvmDir)/\(nodeDir)/bin/\(cli)"
+                    if fm.fileExists(atPath: binPath) { return true }
+                }
+            }
+            for path in searchPaths where fm.fileExists(atPath: path) {
+                return true
+            }
+        }
+
+        // Check evidence paths — tool-specific config files
+        for path in evidencePaths where fm.fileExists(atPath: path) {
+            return true
+        }
+
+        return false
+    }
+
+    var expandedSkillsDir: String {
+        (globalSkillsDir as NSString).expandingTildeInPath
+    }
+
+    static var installed: [AgentTarget] {
+        all.filter(\.isInstalled)
+    }
+
+    static let all: [AgentTarget] = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let configHome: String = {
+            if let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"], !xdg.isEmpty {
+                return xdg
+            }
+            return "\(home)/.config"
+        }()
+
+        return [
+            // CLI tools — detect via binary or config files
+            AgentTarget(
+                id: "claude-code",
+                displayName: "Claude Code",
+                globalSkillsDir: "\(home)/.claude/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(home)/.claude/settings.json",
+                    "\(home)/.claude/CLAUDE.md",
+                    "\(home)/.claude/cache",
+                ],
+                appBundleName: nil,
+                cliBinaryName: "claude"
+            ),
+            AgentTarget(
+                id: "codex",
+                displayName: "Codex",
+                globalSkillsDir: "\(home)/.codex/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(home)/.codex/config.toml",
+                    "\(home)/.codex/auth.json",
+                ],
+                appBundleName: nil,
+                cliBinaryName: "codex"
+            ),
+            AgentTarget(
+                id: "amp",
+                displayName: "Amp",
+                globalSkillsDir: "\(configHome)/amp",
+                skillFileName: "AGENTS.md",
+                evidencePaths: [
+                    "\(configHome)/amp/config.json",
+                    "\(configHome)/amp/settings.json",
+                ],
+                appBundleName: nil,
+                cliBinaryName: "amp"
+            ),
+            AgentTarget(
+                id: "goose",
+                displayName: "Goose",
+                globalSkillsDir: "\(configHome)/goose/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(configHome)/goose/config.yaml",
+                    "\(configHome)/goose/profiles",
+                ],
+                appBundleName: nil,
+                cliBinaryName: "goose"
+            ),
+
+            // IDE/editor apps — detect via /Applications
+            AgentTarget(
+                id: "cursor",
+                displayName: "Cursor",
+                globalSkillsDir: "\(home)/.cursor/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(home)/.cursor/argv.json",
+                    "\(home)/.cursor/extensions",
+                ],
+                appBundleName: "Cursor",
+                cliBinaryName: nil
+            ),
+            AgentTarget(
+                id: "windsurf",
+                displayName: "Windsurf",
+                globalSkillsDir: "\(home)/.codeium/windsurf/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(home)/.codeium/windsurf/argv.json",
+                    "\(home)/.codeium/windsurf/extensions",
+                ],
+                appBundleName: "Windsurf",
+                cliBinaryName: nil
+            ),
+            AgentTarget(
+                id: "warp",
+                displayName: "Warp",
+                globalSkillsDir: "\(home)/.warp/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(home)/.warp/launch_configurations",
+                ],
+                appBundleName: "Warp",
+                cliBinaryName: nil
+            ),
+        ]
+    }()
+}

--- a/Chops/Models/SchemaVersions.swift
+++ b/Chops/Models/SchemaVersions.swift
@@ -1,0 +1,24 @@
+import SwiftData
+import Foundation
+
+// MARK: - V1: Current schema (post-UI-overhaul)
+
+enum SchemaV1: VersionedSchema {
+    static var versionIdentifier: Schema.Version = Schema.Version(1, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [Skill.self, SkillCollection.self]
+    }
+}
+
+// MARK: - Migration Plan
+
+enum ChopsMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [SchemaV1.self]
+    }
+
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/Chops/Services/SkillParser.swift
+++ b/Chops/Services/SkillParser.swift
@@ -12,15 +12,7 @@ enum SkillParser {
                 return MDCParser.parse(content)
             }
             return FrontmatterParser.parse(content)
-        case .codex, .amp:
-            return parseHeadingFormat(content)
-        case .windsurf:
-            return FrontmatterParser.parse(content)
-        case .copilot:
-            return parseHeadingFormat(content)
-        case .aider:
-            return parseHeadingFormat(content)
-        case .custom:
+        case .codex, .amp, .windsurf, .copilot, .aider, .custom:
             // Try frontmatter first, fall back to heading
             let parsed = FrontmatterParser.parse(content)
             if !parsed.name.isEmpty { return parsed }

--- a/Chops/Services/SkillRegistry.swift
+++ b/Chops/Services/SkillRegistry.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+@Observable
+final class SkillRegistry {
+    var isSearching = false
+    var searchError: String?
+
+    // Cache repo trees and default branches to avoid repeated API calls
+    private var treeCache: [String: [String]] = [:] // source -> [SKILL.md paths]
+    private var branchCache: [String: String] = [:] // source -> default branch
+
+    // MARK: - Search
+
+    struct SearchResponse: Codable {
+        let skills: [RegistrySkill]
+        let count: Int
+    }
+
+    struct RegistrySkill: Identifiable, Codable {
+        let id: String
+        let skillId: String
+        let name: String
+        let installs: Int
+        let source: String
+
+        var formattedInstalls: String {
+            if installs >= 1_000_000 {
+                return "\(String(format: "%.1f", Double(installs) / 1_000_000).replacingOccurrences(of: ".0", with: ""))M"
+            } else if installs >= 1_000 {
+                return "\(String(format: "%.1f", Double(installs) / 1_000).replacingOccurrences(of: ".0", with: ""))K"
+            }
+            return "\(installs)"
+        }
+    }
+
+    func search(query: String) async throws -> [RegistrySkill] {
+        guard query.count >= 2 else { return [] }
+
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        let url = URL(string: "https://skills.sh/api/search?q=\(encoded)&limit=30")!
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw RegistryError.searchFailed
+        }
+
+        let decoded = try JSONDecoder().decode(SearchResponse.self, from: data)
+        return decoded.skills
+    }
+
+    // MARK: - Content Resolution
+
+    func fetchContent(skill: RegistrySkill) async throws -> String {
+        let branch = try await getDefaultBranch(source: skill.source)
+        let paths = try await getSkillPaths(source: skill.source, branch: branch)
+
+        // Try each SKILL.md path until we find one whose frontmatter name matches
+        for path in paths {
+            let rawURL = URL(string: "https://raw.githubusercontent.com/\(skill.source)/\(branch)/\(path)")!
+            guard let (data, response) = try? await URLSession.shared.data(from: rawURL),
+                  let http = response as? HTTPURLResponse, http.statusCode == 200,
+                  let content = String(data: data, encoding: .utf8) else {
+                continue
+            }
+
+            // Check if this SKILL.md's frontmatter name matches the skillId
+            let frontmatterName = parseFrontmatterName(from: content)
+            if frontmatterName == skill.skillId || frontmatterName == skill.name {
+                return content
+            }
+        }
+
+        throw RegistryError.skillNotFound
+    }
+
+    private func getDefaultBranch(source: String) async throws -> String {
+        if let cached = branchCache[source] {
+            return cached
+        }
+
+        let url = URL(string: "https://api.github.com/repos/\(source)")!
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            // Fall back to "main" if we can't determine default branch
+            return "main"
+        }
+
+        struct RepoResponse: Codable {
+            let default_branch: String
+        }
+
+        let repo = try JSONDecoder().decode(RepoResponse.self, from: data)
+        branchCache[source] = repo.default_branch
+        return repo.default_branch
+    }
+
+    private func getSkillPaths(source: String, branch: String) async throws -> [String] {
+        if let cached = treeCache[source] {
+            return cached
+        }
+
+        let url = URL(string: "https://api.github.com/repos/\(source)/git/trees/\(branch)?recursive=1")!
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse else {
+            throw RegistryError.treeFetchFailed
+        }
+        if http.statusCode == 403 {
+            throw RegistryError.rateLimited
+        }
+        guard http.statusCode == 200 else {
+            throw RegistryError.treeFetchFailed
+        }
+
+        struct TreeResponse: Codable {
+            struct TreeEntry: Codable {
+                let path: String
+                let type: String
+            }
+            let tree: [TreeEntry]
+        }
+
+        let tree = try JSONDecoder().decode(TreeResponse.self, from: data)
+        let skillPaths = tree.tree
+            .filter { $0.type == "blob" && $0.path.hasSuffix("/SKILL.md") }
+            .map(\.path)
+
+        treeCache[source] = skillPaths
+        return skillPaths
+    }
+
+    private func parseFrontmatterName(from content: String) -> String? {
+        let lines = content.components(separatedBy: .newlines)
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return nil }
+
+        for line in lines.dropFirst() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" { break }
+            if trimmed.hasPrefix("name:") {
+                return trimmed
+                    .dropFirst(5)
+                    .trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Install
+
+    func install(content: String, skillName: String, agents: [AgentTarget]) throws {
+        let sanitized = skillName
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "-")
+            .filter { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "." || $0 == "_" }
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".-"))
+
+        guard !sanitized.isEmpty else {
+            throw RegistryError.invalidSkillName
+        }
+
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+
+        // Canonical location — matches the official skills CLI behavior
+        let canonicalDir = "\(home)/.agents/skills/\(sanitized)"
+        let canonicalFile = "\(canonicalDir)/SKILL.md"
+        let canonicalAlreadyExisted = fm.fileExists(atPath: canonicalFile)
+
+        // Write real file to canonical location if not already there
+        if !canonicalAlreadyExisted {
+            try fm.createDirectory(atPath: canonicalDir, withIntermediateDirectories: true)
+            try content.write(toFile: canonicalFile, atomically: true, encoding: .utf8)
+        }
+
+        // Symlink from each agent's skills dir to the canonical location
+        var newLinks = 0
+        for agent in agents {
+            let agentDir = "\(agent.expandedSkillsDir)/\(sanitized)"
+
+            // Skip if already installed (real file or symlink)
+            if fm.fileExists(atPath: agentDir) { continue }
+
+            // Create parent dir if needed
+            try fm.createDirectory(atPath: agent.expandedSkillsDir, withIntermediateDirectories: true)
+
+            // Create symlink to canonical dir
+            try fm.createSymbolicLink(atPath: agentDir, withDestinationPath: canonicalDir)
+            newLinks += 1
+        }
+
+        if newLinks == 0 && canonicalAlreadyExisted {
+            throw RegistryError.skillAlreadyExists
+        }
+    }
+
+    // MARK: - Errors
+
+    enum RegistryError: LocalizedError {
+        case searchFailed
+        case treeFetchFailed
+        case rateLimited
+        case skillNotFound
+        case invalidSkillName
+        case skillAlreadyExists
+
+        var errorDescription: String? {
+            switch self {
+            case .searchFailed: "Search request failed"
+            case .treeFetchFailed: "Could not fetch repository contents"
+            case .rateLimited: "GitHub API rate limit reached — try again in a few minutes"
+            case .skillNotFound: "Skill file not found in repository"
+            case .invalidSkillName: "Invalid skill name"
+            case .skillAlreadyExists: "Skill is already installed for all selected agents"
+            }
+        }
+    }
+}

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -81,19 +81,25 @@ final class SkillScanner {
             if fm.fileExists(atPath: agentsMD.path) {
                 upsertSkill(at: agentsMD, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal)
             }
-            // Also scan subdirectories for skills
-            if let contents = try? fm.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            ) {
+            // Scan subdirectories for skills (SKILL.md or AGENTS.md)
+            // The official skills CLI installs SKILL.md into subdirectories here
+            let scanDirs = [directory, directory.appendingPathComponent("skills")]
+            for scanDir in scanDirs {
+                guard let contents = try? fm.contentsOfDirectory(
+                    at: scanDir,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                ) else { continue }
                 for item in contents {
                     var itemIsDir: ObjCBool = false
                     fm.fileExists(atPath: item.path, isDirectory: &itemIsDir)
                     if itemIsDir.boolValue {
-                        let skillFile = item.appendingPathComponent("AGENTS.md")
+                        let skillFile = item.appendingPathComponent("SKILL.md")
+                        let agentsFile = item.appendingPathComponent("AGENTS.md")
                         if fm.fileExists(atPath: skillFile.path) {
                             upsertSkill(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal)
+                        } else if fm.fileExists(atPath: agentsFile.path) {
+                            upsertSkill(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal)
                         }
                     }
                 }

--- a/Chops/Views/Shared/RegistrySheet.swift
+++ b/Chops/Views/Shared/RegistrySheet.swift
@@ -1,0 +1,368 @@
+import SwiftUI
+
+struct RegistrySheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var registry = SkillRegistry()
+    @State private var searchText = ""
+    @State private var results: [SkillRegistry.RegistrySkill] = []
+    @State private var selectedSkill: SkillRegistry.RegistrySkill?
+    @State private var skillContent: String?
+    @State private var selectedAgents: Set<String> = []
+    @State private var isSearching = false
+    @State private var isFetchingContent = false
+    @State private var isInstalling = false
+    @State private var error: String?
+    @State private var installSuccess = false
+    @State private var searchTask: Task<Void, Never>?
+    @State private var contentTask: Task<Void, Never>?
+
+    private var installedAgents: [AgentTarget] {
+        AgentTarget.installed
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                if selectedSkill != nil {
+                    Button {
+                        withAnimation {
+                            contentTask?.cancel()
+                            selectedSkill = nil
+                            skillContent = nil
+                            error = nil
+                            installSuccess = false
+                            isFetchingContent = false
+                        }
+                    } label: {
+                        Label("Back", systemImage: "chevron.left")
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                Text(selectedSkill != nil ? "Install Skill" : "Browse Skills")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+
+                Spacer()
+
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 12)
+
+            Divider()
+
+            if let skill = selectedSkill {
+                installView(skill: skill)
+            } else {
+                searchView
+            }
+        }
+        .frame(width: 560, height: 500)
+        .onAppear {
+            // Pre-select all installed agents
+            selectedAgents = Set(installedAgents.map(\.id))
+        }
+        .onDisappear {
+            searchTask?.cancel()
+            contentTask?.cancel()
+        }
+    }
+
+    // MARK: - Search Phase
+
+    private var searchView: some View {
+        VStack(spacing: 0) {
+            // Search field
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search skills (e.g. react, testing, deploy)...", text: $searchText)
+                    .textFieldStyle(.plain)
+                if isSearching {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+            .padding(10)
+            .background(.quaternary.opacity(0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .onChange(of: searchText) { _, newValue in
+                debounceSearch(query: newValue)
+            }
+
+            Divider()
+
+            // Results
+            if results.isEmpty && !isSearching && searchText.isEmpty {
+                ContentUnavailableView {
+                    Label("Search the Skills Registry", systemImage: "globe")
+                } description: {
+                    Text("Find and install skills from the open agent skills ecosystem.")
+                }
+                .frame(maxHeight: .infinity)
+            } else if results.isEmpty && !isSearching && !searchText.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+                    .frame(maxHeight: .infinity)
+            } else {
+                List(results) { skill in
+                    Button {
+                        selectSkill(skill)
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(skill.name)
+                                    .fontWeight(.medium)
+                                Text(skill.source)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Text("\(skill.formattedInstalls) installs")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .listStyle(.plain)
+            }
+
+            if let error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 8)
+            }
+        }
+    }
+
+    // MARK: - Install Phase
+
+    private func installView(skill: SkillRegistry.RegistrySkill) -> some View {
+        VStack(spacing: 0) {
+            if isFetchingContent {
+                Spacer()
+                ProgressView("Loading skill content...")
+                Spacer()
+            } else if let content = skillContent {
+                // Content preview
+                ScrollView {
+                    Text(content)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                }
+                .frame(maxHeight: 200)
+                .background(.quaternary.opacity(0.3))
+
+                Divider()
+
+                // Agent selection
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Install to:")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+
+                        Spacer()
+
+                        if !installedAgents.isEmpty {
+                            let allSelected = selectedAgents.count == installedAgents.count
+                            Button(allSelected ? "Deselect All" : "Select All") {
+                                if allSelected {
+                                    selectedAgents.removeAll()
+                                } else {
+                                    selectedAgents = Set(installedAgents.map(\.id))
+                                }
+                            }
+                            .font(.caption)
+                            .buttonStyle(.plain)
+                            .foregroundColor(.accentColor)
+                        }
+                    }
+
+                    if installedAgents.isEmpty {
+                        Text("No supported agents detected on this machine.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ScrollView {
+                            VStack(spacing: 0) {
+                                ForEach(installedAgents) { agent in
+                                    HStack(spacing: 8) {
+                                        Image(systemName: selectedAgents.contains(agent.id) ? "checkmark.circle.fill" : "circle")
+                                            .foregroundColor(selectedAgents.contains(agent.id) ? .accentColor : .secondary)
+                                            .font(.system(size: 14))
+
+                                        Text(agent.displayName)
+                                            .font(.system(size: 12))
+
+                                        Spacer()
+                                    }
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        if selectedAgents.contains(agent.id) {
+                                            selectedAgents.remove(agent.id)
+                                        } else {
+                                            selectedAgents.insert(agent.id)
+                                        }
+                                    }
+                                    .padding(.vertical, 4)
+                                    .padding(.horizontal, 4)
+                                }
+                            }
+                        }
+                        .frame(maxHeight: 140)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+
+                Divider()
+
+                // Install button
+                HStack {
+                    if let error {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+
+                    if installSuccess {
+                        Label("Installed!", systemImage: "checkmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
+
+                    Spacer()
+
+                    Button {
+                        performInstall(content: content, skillName: skill.skillId)
+                    } label: {
+                        if isInstalling {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Text("Install")
+                        }
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(selectedAgents.isEmpty || isInstalling || installSuccess)
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+            } else if let error {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func debounceSearch(query: String) {
+        searchTask?.cancel()
+        error = nil
+
+        guard query.count >= 2 else {
+            results = []
+            return
+        }
+
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run { isSearching = true }
+
+            do {
+                let skills = try await registry.search(query: query)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    results = skills
+                    isSearching = false
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    self.error = error.localizedDescription
+                    isSearching = false
+                }
+            }
+        }
+    }
+
+    private func selectSkill(_ skill: SkillRegistry.RegistrySkill) {
+        contentTask?.cancel()
+        selectedSkill = skill
+        skillContent = nil
+        error = nil
+        installSuccess = false
+        isFetchingContent = true
+
+        contentTask = Task {
+            do {
+                let content = try await registry.fetchContent(skill: skill)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    guard selectedSkill?.id == skill.id else { return }
+                    self.skillContent = content
+                    self.isFetchingContent = false
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    guard selectedSkill?.id == skill.id else { return }
+                    self.error = error.localizedDescription
+                    self.isFetchingContent = false
+                }
+            }
+        }
+    }
+
+    private func performInstall(content: String, skillName: String) {
+        let agents = installedAgents.filter { selectedAgents.contains($0.id) }
+        guard !agents.isEmpty else { return }
+
+        isInstalling = true
+        error = nil
+
+        do {
+            try registry.install(content: content, skillName: skillName, agents: agents)
+            installSuccess = true
+            isInstalling = false
+
+            // Trigger re-scan so the new skill appears immediately
+            NotificationCenter.default.post(name: .customScanPathsChanged, object: nil)
+
+            // Auto-dismiss after brief delay
+            Task {
+                try? await Task.sleep(for: .milliseconds(800))
+                await MainActor.run { dismiss() }
+            }
+        } catch {
+            self.error = error.localizedDescription
+            isInstalling = false
+        }
+    }
+}

--- a/Chops/Views/Shared/ToolBadge.swift
+++ b/Chops/Views/Shared/ToolBadge.swift
@@ -27,6 +27,7 @@ struct ToolIcon: View {
                 .frame(width: size, height: size)
         } else {
             Image(systemName: tool.iconName)
+                .font(.system(size: size * 0.7))
                 .frame(width: size, height: size)
         }
     }

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -78,9 +78,15 @@ struct SkillRow: View {
     let skill: Skill
 
     var body: some View {
-        HStack {
+        HStack(spacing: 6) {
             Text(skill.name)
                 .lineLimit(1)
+
+            if skill.isFavorite {
+                Image(systemName: "star.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.yellow)
+            }
 
             Spacer()
 
@@ -91,12 +97,15 @@ struct SkillRow: View {
                     .lineLimit(1)
             }
 
-            if skill.isFavorite {
-                Image(systemName: "star.fill")
-                    .font(.caption2)
-                    .foregroundStyle(.yellow)
+            HStack(spacing: 3) {
+                ForEach(skill.toolSources, id: \.self) { tool in
+                    ToolIcon(tool: tool, size: 14)
+                        .help(tool.displayName)
+                        .opacity(0.6)
+                }
             }
         }
         .padding(.vertical, 4)
     }
 }
+


### PR DESCRIPTION
## Summary

- Adds a "Browse Registry" option to the toolbar menu that searches the skills.sh registry (same API as the official `npx skills` CLI)
- Resolves skill content via GitHub Trees API, matching frontmatter `name` to the search result's `skillId`
- Installs to a canonical `~/.agents/skills/` directory with symlinks to each selected agent, matching the official CLI's install pattern
- Detects installed agents (Claude Code, Cursor, Codex, etc.) via app bundles, CLI binaries, and config files — not just directory existence
- Shows per-skill tool icons in the list view indicating which agents have each skill installed
- Fixes SkillParser to try frontmatter before heading extraction for all tool types (Codex/Amp/Copilot/Aider)
- Fixes SkillScanner to find SKILL.md files in Codex/Amp subdirectories (not just AGENTS.md)

## Test plan

- [ ] Click "+" toolbar → "Browse Registry"
- [ ] Search for a skill (e.g. "react") and verify results with install counts
- [ ] Select a skill, verify content preview loads
- [ ] Verify only actually-installed agents appear as checkboxes
- [ ] Install to multiple agents, verify symlinks created in each agent's skills dir
- [ ] Verify skill appears in main list with correct tool icons
- [ ] Verify FileWatcher picks up newly installed skills

Fixes #5