### PR TITLE
Add markdown preview mode with syntax highlighting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ open Chops.xcodeproj
 # CLI build
 xcodebuild -scheme Chops -configuration Release
 
+# Local release-like build that launches cleanly from shell
+xcodebuild -scheme Chops -configuration LocalRelease
+
 # Release (needs APPLE_TEAM_ID, APPLE_ID, SIGNING_IDENTITY_NAME env vars)
 ./scripts/release.sh <version>
 ```
@@ -25,6 +28,12 @@ xcodebuild -scheme Chops -configuration Release
 Requires: Xcode, `brew install xcodegen`, macOS 15+. Sparkle (>= 2.6.0) is the only external dependency (auto-updates via GitHub Releases).
 
 No test suite exists. Validate manually by building and running.
+
+## Development Rules
+
+**Always manually test.** After every change, build the app (`xcodebuild`), launch it, and exercise the feature you changed. Seeing "build succeeded" is not enough — open the app and verify the actual behavior. If it's a UI change, look at it. If it's a data change, confirm the data. No exceptions.
+
+**No fallbacks.** Do not write fallback logic, graceful degradation, or backwards-compatibility shims. The product should work correctly via the primary code path. If something fails, fix the root cause — don't paper over it with a fallback. We are early-stage; the code should be clean and direct, not defensive.
 
 ## Architecture
 

--- a/Chops.xcodeproj/project.pbxproj
+++ b/Chops.xcodeproj/project.pbxproj
@@ -16,14 +16,17 @@
 		60A6711BAB0C3B8A3ACBF985 /* SkillParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5155D141EF812A3FE9ADF59C /* SkillParser.swift */; };
 		6A8E0927D95BB14C9F377F4E /* SkillScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A5B26D335C1AFB6CDE8207 /* SkillScanner.swift */; };
 		71E92A838AB4D1D6DC6174AF /* NewSkillSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02A00F80E4712872205EA7B /* NewSkillSheet.swift */; };
+		791AA125E9170DBA81BCBE62 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = B79B2B9912FC7D2ADEA22F84 /* MarkdownUI */; };
 		7A17C99C5EFAE3AA9E788D50 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AFE1AF02B0F8057791C2A9 /* Collection.swift */; };
 		7EC6156934D559226BC78859 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA102A49ACFB23BC15794F8 /* CollectionListView.swift */; };
 		7FD1DE6640F9339D5E97E09A /* MDCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4F680B33C74A38FCF5ADD5 /* MDCParser.swift */; };
+		801A39D725B59A2F2BAF5DF2 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = 704A14702546BFBD29BE27A8 /* Highlightr */; };
 		846B58F3B105D1734DC6FA75 /* SkillRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC9D3E83D8640CC258CF361 /* SkillRegistry.swift */; };
 		87A469B631CC80C89B14B1C7 /* SkillMetadataBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C812515FD8DC222B89745F2 /* SkillMetadataBar.swift */; };
 		95163AEB7980654C901EC693 /* Skill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D6ED655F951177D2152351 /* Skill.swift */; };
 		98434D3DDFEEC7239F6F7B79 /* RegistrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCD6C2A8BE68F553A9CA392 /* RegistrySheet.swift */; };
 		99EE8F6124FE91AC9576D6FD /* FileWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */; };
+		9ED88D6237B36693ABE5CE85 /* HighlightrSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57F2C41F08F6E1BEFC5ADD4 /* HighlightrSyntaxHighlighter.swift */; };
 		B5B95B9DA63A734F25470FF5 /* SchemaVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F8AA042D5D8A9F92F35CA3 /* SchemaVersions.swift */; };
 		BD584933CCE2B650345C4CF1 /* ToolSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5487D9027B97F7E9EE9A1F4A /* ToolSource.swift */; };
 		C30BEAE03E54BD36F257A925 /* ToolFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5774429CCE83C2AFBE046C /* ToolFilterView.swift */; };
@@ -32,6 +35,7 @@
 		CCD92CB102DFA0965D6AFDB5 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF7822031FD82A28978D9C5 /* SidebarView.swift */; };
 		CECE9BEEC1D933C543B66A4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 17F7FE50C96124BA4EE43A6F /* Assets.xcassets */; };
 		D4C107BE303FC07CAF9C66AF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E0F71982C4AF0045962380 /* ContentView.swift */; };
+		E6F4E1CF50F2F78F5BA9BAC9 /* SkillPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E332B9970E6E3D00DCFBA3 /* SkillPreviewView.swift */; };
 		E98F7490B18A194F82ED2C0E /* SkillListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA64A368BBF950CD36C4F495 /* SkillListView.swift */; };
 		F98B1E8579B139FD2A801650 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC47BDE92105F4736B379F /* SearchService.swift */; };
 		FB295303DD30AED03290C726 /* SkillEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B4DB87833D5160A11E39C9 /* SkillEditorView.swift */; };
@@ -52,6 +56,7 @@
 		5155D141EF812A3FE9ADF59C /* SkillParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillParser.swift; sourceTree = "<group>"; };
 		5487D9027B97F7E9EE9A1F4A /* ToolSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSource.swift; sourceTree = "<group>"; };
 		60E0F71982C4AF0045962380 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		77E332B9970E6E3D00DCFBA3 /* SkillPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillPreviewView.swift; sourceTree = "<group>"; };
 		7C77C5B30E6C885B39444E5B /* FrontmatterParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterParser.swift; sourceTree = "<group>"; };
 		7FCD6C2A8BE68F553A9CA392 /* RegistrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrySheet.swift; sourceTree = "<group>"; };
 		7FFC47BDE92105F4736B379F /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
@@ -66,6 +71,7 @@
 		B3F5CF5BB1FC8455FDDB004A /* Chops.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chops.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9AFE1AF02B0F8057791C2A9 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWatcher.swift; sourceTree = "<group>"; };
+		D57F2C41F08F6E1BEFC5ADD4 /* HighlightrSyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightrSyntaxHighlighter.swift; sourceTree = "<group>"; };
 		E6A5B26D335C1AFB6CDE8207 /* SkillScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillScanner.swift; sourceTree = "<group>"; };
 		F02A00F80E4712872205EA7B /* NewSkillSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSkillSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -76,6 +82,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				331F55021A7E6C9F0B666514 /* Sparkle in Frameworks */,
+				791AA125E9170DBA81BCBE62 /* MarkdownUI in Frameworks */,
+				801A39D725B59A2F2BAF5DF2 /* Highlightr in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				7C77C5B30E6C885B39444E5B /* FrontmatterParser.swift */,
+				D57F2C41F08F6E1BEFC5ADD4 /* HighlightrSyntaxHighlighter.swift */,
 				3A4F680B33C74A38FCF5ADD5 /* MDCParser.swift */,
 			);
 			path = Utilities;
@@ -193,6 +202,7 @@
 				168E103488DEA623E712852B /* SkillDetailView.swift */,
 				31B4DB87833D5160A11E39C9 /* SkillEditorView.swift */,
 				8C812515FD8DC222B89745F2 /* SkillMetadataBar.swift */,
+				77E332B9970E6E3D00DCFBA3 /* SkillPreviewView.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -231,6 +241,8 @@
 			name = Chops;
 			packageProductDependencies = (
 				4338FC540625A275BBC9AAC9 /* Sparkle */,
+				B79B2B9912FC7D2ADEA22F84 /* MarkdownUI */,
+				704A14702546BFBD29BE27A8 /* Highlightr */,
 			);
 			productName = Chops;
 			productReference = B3F5CF5BB1FC8455FDDB004A /* Chops.app */;
@@ -257,6 +269,8 @@
 			mainGroup = 08ECEAD013847D8F110E61B4;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				7FA62842E4E9A8FD27AE24AF /* XCRemoteSwiftPackageReference "Highlightr" */,
+				7F6181572A727350272D9BEC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				FD1D69AB767CC40E2CE9FED9 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -294,6 +308,7 @@
 				D4C107BE303FC07CAF9C66AF /* ContentView.swift in Sources */,
 				99EE8F6124FE91AC9576D6FD /* FileWatcher.swift in Sources */,
 				CBD8FECF1C5A453C8B021665 /* FrontmatterParser.swift in Sources */,
+				9ED88D6237B36693ABE5CE85 /* HighlightrSyntaxHighlighter.swift in Sources */,
 				7FD1DE6640F9339D5E97E09A /* MDCParser.swift in Sources */,
 				71E92A838AB4D1D6DC6174AF /* NewSkillSheet.swift in Sources */,
 				98434D3DDFEEC7239F6F7B79 /* RegistrySheet.swift in Sources */,
@@ -307,6 +322,7 @@
 				E98F7490B18A194F82ED2C0E /* SkillListView.swift in Sources */,
 				87A469B631CC80C89B14B1C7 /* SkillMetadataBar.swift in Sources */,
 				60A6711BAB0C3B8A3ACBF985 /* SkillParser.swift in Sources */,
+				E6F4E1CF50F2F78F5BA9BAC9 /* SkillPreviewView.swift in Sources */,
 				846B58F3B105D1734DC6FA75 /* SkillRegistry.swift in Sources */,
 				6A8E0927D95BB14C9F377F4E /* SkillScanner.swift in Sources */,
 				53C393C13E30EC439317509F /* ToolBadge.swift in Sources */,
@@ -373,6 +389,28 @@
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
+		};
+		48F3C139C64DA85863FE9C21 /* LocalRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = ChopsIcon;
+				CODE_SIGN_ENTITLEMENTS = Chops/ChopsLocalRelease.entitlements;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Chops/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.joshpigford.Chops;
+				SDKROOT = macosx;
+				SWIFT_STRICT_CONCURRENCY = minimal;
+			};
+			name = LocalRelease;
 		};
 		52738EE717474F8671BFB266 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -481,6 +519,62 @@
 			};
 			name = Debug;
 		};
+		9095D323E2CCDA0C5D19CDAE /* LocalRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = LocalRelease;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -488,6 +582,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				52738EE717474F8671BFB266 /* Debug */,
+				48F3C139C64DA85863FE9C21 /* LocalRelease */,
 				58C6E63A67ADDC4C7CB7ED9D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -497,6 +592,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				67CFFB04E52F4383BF75357C /* Debug */,
+				9095D323E2CCDA0C5D19CDAE /* LocalRelease */,
 				31FDAD4740108C316B09117A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -505,6 +601,22 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		7F6181572A727350272D9BEC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+		7FA62842E4E9A8FD27AE24AF /* XCRemoteSwiftPackageReference "Highlightr" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/raspu/Highlightr";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.1;
+			};
+		};
 		FD1D69AB767CC40E2CE9FED9 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -520,6 +632,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FD1D69AB767CC40E2CE9FED9 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		704A14702546BFBD29BE27A8 /* Highlightr */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7FA62842E4E9A8FD27AE24AF /* XCRemoteSwiftPackageReference "Highlightr" */;
+			productName = Highlightr;
+		};
+		B79B2B9912FC7D2ADEA22F84 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7F6181572A727350272D9BEC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Chops.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Chops.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
+  "originHash" : "d0e9b55e5a1f995aa86a208c3c1677dc39f38b65031258ce388e8453d06a06c8",
   "pins" : [
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
@@ -8,6 +26,24 @@
       "state" : {
         "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
         "version" : "2.9.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     }
   ],

--- a/Chops/ChopsLocalRelease.entitlements
+++ b/Chops/ChopsLocalRelease.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/Chops/Utilities/HighlightrSyntaxHighlighter.swift
+++ b/Chops/Utilities/HighlightrSyntaxHighlighter.swift
@@ -1,0 +1,22 @@
+import MarkdownUI
+import Highlightr
+import SwiftUI
+
+struct HighlightrSyntaxHighlighter: CodeSyntaxHighlighter {
+    private let highlightr: Highlightr
+
+    init() {
+        let h = Highlightr()!
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        h.setTheme(to: isDark ? "atom-one-dark" : "atom-one-light")
+        self.highlightr = h
+    }
+
+    func highlightCode(_ code: String, language: String?) -> Text {
+        let lang = language ?? "plaintext"
+        if let highlighted = highlightr.highlight(code, as: lang) {
+            return Text(AttributedString(highlighted))
+        }
+        return Text(code)
+    }
+}

--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -4,17 +4,44 @@ import SwiftData
 struct SkillDetailView: View {
     @Bindable var skill: Skill
     @Environment(\.modelContext) private var modelContext
+    @AppStorage("preferPreview") private var preferPreview = false
+    @State private var document = SkillEditorDocument()
 
     var body: some View {
+        @Bindable var document = document
+
         VStack(spacing: 0) {
-            SkillEditorView(skill: skill)
+            if preferPreview {
+                SkillPreviewView(content: document.editorContent)
+            } else {
+                SkillEditorView(document: document)
+            }
 
             Divider()
 
             SkillMetadataBar(skill: skill)
         }
         .navigationTitle(skill.name)
+        .onAppear {
+            document.load(from: skill)
+        }
+        .onChange(of: skill.filePath) {
+            document.load(from: skill)
+        }
+        .focusedValue(\.saveAction, SaveAction(action: { document.save(to: skill) }))
+        .alert("Save Error", isPresented: $document.showingSaveError) {
+            Button("OK") {}
+        } message: {
+            Text(document.saveErrorMessage)
+        }
         .toolbar {
+            ToolbarItem {
+                Picker("Mode", selection: $preferPreview) {
+                    Image(systemName: "pencil").tag(false)
+                    Image(systemName: "eye").tag(true)
+                }
+                .pickerStyle(.segmented)
+            }
             ToolbarItem {
                 Button {
                     skill.isFavorite.toggle()

--- a/Chops/Views/Detail/SkillEditorView.swift
+++ b/Chops/Views/Detail/SkillEditorView.swift
@@ -1,46 +1,24 @@
 import SwiftUI
 import AppKit
 
-struct SkillEditorView: View {
-    @Bindable var skill: Skill
-    @State private var editorContent: String = ""
-    @State private var hasUnsavedChanges = false
-    @State private var showingSaveError = false
-    @State private var saveErrorMessage = ""
-    @State private var fullFileContent: String = ""
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            HighlightedTextEditor(text: $editorContent)
-
-            if hasUnsavedChanges {
-                Text("Modified")
-                    .font(.caption)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(.orange.opacity(0.2), in: Capsule())
-                    .foregroundStyle(.orange)
-                    .padding(12)
-            }
-        }
-        .onChange(of: editorContent) {
+@Observable
+final class SkillEditorDocument {
+    var editorContent: String = "" {
+        didSet {
+            guard !isLoading else { return }
             hasUnsavedChanges = editorContent != fullFileContent
         }
-        .onAppear {
-            loadContent()
-        }
-        .onChange(of: skill.filePath) {
-            loadContent()
-        }
-        .focusedValue(\.saveAction, SaveAction(action: saveFile))
-        .alert("Save Error", isPresented: $showingSaveError) {
-            Button("OK") {}
-        } message: {
-            Text(saveErrorMessage)
-        }
     }
+    var hasUnsavedChanges = false
+    var showingSaveError = false
+    var saveErrorMessage = ""
 
-    private func loadContent() {
+    private var fullFileContent: String = ""
+    private var isLoading = false
+
+    func load(from skill: Skill) {
+        isLoading = true
+
         if let data = try? String(contentsOfFile: skill.filePath, encoding: .utf8) {
             editorContent = data
             fullFileContent = data
@@ -48,10 +26,14 @@ struct SkillEditorView: View {
             editorContent = skill.content
             fullFileContent = skill.content
         }
+
+        isLoading = false
         hasUnsavedChanges = false
+        showingSaveError = false
+        saveErrorMessage = ""
     }
 
-    private func saveFile() {
+    func save(to skill: Skill) {
         do {
             try editorContent.write(toFile: skill.filePath, atomically: true, encoding: .utf8)
             fullFileContent = editorContent
@@ -64,9 +46,33 @@ struct SkillEditorView: View {
             skill.skillDescription = parsed.description
             skill.content = parsed.content
             skill.frontmatter = parsed.frontmatter
+
+            let attrs = try? FileManager.default.attributesOfItem(atPath: skill.filePath)
+            skill.fileModifiedDate = (attrs?[.modificationDate] as? Date) ?? skill.fileModifiedDate
+            skill.fileSize = (attrs?[.size] as? Int) ?? skill.fileSize
         } catch {
             saveErrorMessage = error.localizedDescription
             showingSaveError = true
+        }
+    }
+}
+
+struct SkillEditorView: View {
+    @Bindable var document: SkillEditorDocument
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            HighlightedTextEditor(text: $document.editorContent)
+
+            if document.hasUnsavedChanges {
+                Text("Modified")
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.orange.opacity(0.2), in: Capsule())
+                    .foregroundStyle(.orange)
+                    .padding(12)
+            }
         }
     }
 }

--- a/Chops/Views/Detail/SkillPreviewView.swift
+++ b/Chops/Views/Detail/SkillPreviewView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import MarkdownUI
+
+struct SkillPreviewView: View {
+    let content: String
+
+    var body: some View {
+        ScrollView {
+            Markdown(strippedContent)
+                .markdownCodeSyntaxHighlighter(HighlightrSyntaxHighlighter())
+                .textSelection(.enabled)
+                .padding()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var strippedContent: String {
+        FrontmatterParser.parse(content).content
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -6,10 +6,21 @@ options:
   createIntermediateGroups: true
   generateEmptyDirectories: true
 
+configs:
+  Debug: debug
+  Release: release
+  LocalRelease: release
+
 packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     from: "2.6.0"
+  MarkdownUI:
+    url: https://github.com/gonzalezreal/swift-markdown-ui
+    from: "2.4.0"
+  Highlightr:
+    url: https://github.com/raspu/Highlightr
+    from: "2.2.1"
 
 targets:
   Chops:
@@ -22,6 +33,8 @@ targets:
           - Info.plist
     dependencies:
       - package: Sparkle
+      - package: MarkdownUI
+      - package: Highlightr
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.joshpigford.Chops
@@ -34,3 +47,6 @@ targets:
         SWIFT_STRICT_CONCURRENCY: minimal
         ASSETCATALOG_COMPILER_APPICON_NAME: ChopsIcon
         ENABLE_HARDENED_RUNTIME: YES
+      configs:
+        LocalRelease:
+          CODE_SIGN_ENTITLEMENTS: Chops/ChopsLocalRelease.entitlements


### PR DESCRIPTION
## Summary
- Adds a segmented edit/preview toggle in the detail toolbar that renders skill markdown with full formatting and syntax-highlighted code blocks
- Preview mode preference persists across sessions via `@AppStorage`
- Extracts `SkillEditorDocument` so editor content is shared between edit and preview modes (unsaved edits visible in preview)
- Adds MarkdownUI and Highlightr as dependencies
- Adds development rules to CLAUDE.md (manual testing, no fallbacks)

Fixes #12