### PR TITLE
Add ability to delete/remove skills

### DIFF
--- a/Chops.xcodeproj/project.pbxproj
+++ b/Chops.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = ChopsIcon;
 				CODE_SIGN_ENTITLEMENTS = Chops/Chops.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_HARDENED_RUNTIME = YES;

--- a/Chops/Models/Skill.swift
+++ b/Chops/Models/Skill.swift
@@ -132,4 +132,44 @@ final class Skill {
             toolSources = tools
         }
     }
+
+    var deletionTargets: [String] {
+        Array(
+            Set(
+                ([filePath] + installedPaths).map { path in
+                    if isDirectory {
+                        return (path as NSString).deletingLastPathComponent
+                    }
+                    return path
+                }
+            )
+        ).sorted()
+    }
+
+    func deleteFromDisk() throws {
+        let fm = FileManager.default
+
+        for path in deletionTargets where fm.fileExists(atPath: path) {
+            guard fm.isDeletableFile(atPath: path) else {
+                throw SkillDeletionError.notDeletable(path)
+            }
+        }
+
+        for path in deletionTargets where fm.fileExists(atPath: path) {
+            try fm.removeItem(atPath: path)
+        }
+    }
+}
+
+enum SkillDeletionError: LocalizedError {
+    case notDeletable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notDeletable(let path):
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let displayPath = path.replacingOccurrences(of: home, with: "~")
+            return "Couldn't delete \(displayPath). Check permissions and try again."
+        }
+    }
 }

--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -2,10 +2,26 @@ import SwiftUI
 import SwiftData
 
 struct SkillDetailView: View {
+    private enum ActiveAlert: Identifiable {
+        case confirmDelete
+        case deleteError(String)
+
+        var id: String {
+            switch self {
+            case .confirmDelete:
+                return "confirm-delete"
+            case .deleteError(let message):
+                return "delete-error-\(message)"
+            }
+        }
+    }
+
     @Bindable var skill: Skill
     @Environment(\.modelContext) private var modelContext
+    @Environment(AppState.self) private var appState
     @AppStorage("preferPreview") private var preferPreview = false
     @State private var document = SkillEditorDocument()
+    @State private var activeAlert: ActiveAlert?
 
     var body: some View {
         @Bindable var document = document
@@ -59,6 +75,44 @@ struct SkillDetailView: View {
                 }
                 .help("Show in Finder")
             }
+            ToolbarItem {
+                Button {
+                    activeAlert = .confirmDelete
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .help("Delete Skill")
+            }
+        }
+        .alert(item: $activeAlert) { alert in
+            switch alert {
+            case .confirmDelete:
+                return Alert(
+                    title: Text("Delete Skill?"),
+                    message: Text("This will permanently delete \"\(skill.name)\" from disk."),
+                    primaryButton: .destructive(Text("Delete")) {
+                        deleteSkill()
+                    },
+                    secondaryButton: .cancel()
+                )
+            case .deleteError(let message):
+                return Alert(
+                    title: Text("Delete Failed"),
+                    message: Text(message),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+        }
+    }
+
+    private func deleteSkill() {
+        do {
+            try skill.deleteFromDisk()
+            appState.selectedSkill = nil
+            modelContext.delete(skill)
+            try modelContext.save()
+        } catch {
+            activeAlert = .deleteError(error.localizedDescription)
         }
     }
 }

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -2,9 +2,24 @@ import SwiftUI
 import SwiftData
 
 struct SkillListView: View {
+    private enum ActiveAlert: Identifiable {
+        case confirmDelete(Skill)
+        case deleteError(String)
+
+        var id: String {
+            switch self {
+            case .confirmDelete(let skill):
+                return "confirm-delete-\(skill.filePath)"
+            case .deleteError(let message):
+                return "delete-error-\(message)"
+            }
+        }
+    }
+
     @Environment(\.modelContext) private var modelContext
     @Environment(AppState.self) private var appState
     @Query(sort: \Skill.name) private var allSkills: [Skill]
+    @State private var activeAlert: ActiveAlert?
 
     private var filteredSkills: [Skill] {
         var result = allSkills
@@ -42,6 +57,19 @@ struct SkillListView: View {
         }
     }
 
+    private func deleteSkill(_ skill: Skill) {
+        do {
+            try skill.deleteFromDisk()
+            if appState.selectedSkill == skill {
+                appState.selectedSkill = nil
+            }
+            modelContext.delete(skill)
+            try modelContext.save()
+        } catch {
+            activeAlert = .deleteError(error.localizedDescription)
+        }
+    }
+
     var body: some View {
         @Bindable var appState = appState
 
@@ -58,10 +86,33 @@ struct SkillListView: View {
                         Button("Show in Finder") {
                             NSWorkspace.shared.selectFile(skill.filePath, inFileViewerRootedAtPath: "")
                         }
+                        Divider()
+                        Button("Delete", role: .destructive) {
+                            activeAlert = .confirmDelete(skill)
+                        }
                     }
             }
         }
         .navigationTitle(title)
+        .alert(item: $activeAlert) { alert in
+            switch alert {
+            case .confirmDelete(let skill):
+                return Alert(
+                    title: Text("Delete Skill?"),
+                    message: Text("This will permanently delete \"\(skill.name)\" from disk."),
+                    primaryButton: .destructive(Text("Delete")) {
+                        deleteSkill(skill)
+                    },
+                    secondaryButton: .cancel()
+                )
+            case .deleteError(let message):
+                return Alert(
+                    title: Text("Delete Failed"),
+                    message: Text(message),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+        }
         .overlay {
             if filteredSkills.isEmpty {
                 ContentUnavailableView(
@@ -108,4 +159,3 @@ struct SkillRow: View {
         .padding(.vertical, 4)
     }
 }
-


### PR DESCRIPTION
## Summary
- Adds a "Delete" option to the skill list right-click context menu and a trash icon button to the detail view toolbar
- Both trigger a confirmation alert before permanently deleting skill files from disk and removing the SwiftData record
- Handles multi-tool installations (deletes all copies), directory-based skills, and surfaces errors if deletion fails

## Test plan
- Right-click a skill in the list → "Delete" → confirm → skill removed from list and file deleted from disk
- Select a skill → click trash icon in toolbar → confirm → same behavior
- Verify selection clears after deletion
- Cancel the alert and verify nothing is deleted