### PR TITLE
feat: add diagnostic logging and fix UI freezing

### DIFF
--- a/Chops.xcodeproj/project.pbxproj
+++ b/Chops.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		98434D3DDFEEC7239F6F7B79 /* RegistrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCD6C2A8BE68F553A9CA392 /* RegistrySheet.swift */; };
 		99EE8F6124FE91AC9576D6FD /* FileWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */; };
 		9ED88D6237B36693ABE5CE85 /* HighlightrSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57F2C41F08F6E1BEFC5ADD4 /* HighlightrSyntaxHighlighter.swift */; };
+		A99BA179E0520DCDC98E1382 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45D5C8E8C732B2F4A867E43 /* AppLogger.swift */; };
+		AFDC3DAB708B352A7606F119 /* DiagnosticExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D3C2567FBF8DBA4DE957B3 /* DiagnosticExporter.swift */; };
 		B5B95B9DA63A734F25470FF5 /* SchemaVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F8AA042D5D8A9F92F35CA3 /* SchemaVersions.swift */; };
 		BD584933CCE2B650345C4CF1 /* ToolSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5487D9027B97F7E9EE9A1F4A /* ToolSource.swift */; };
 		C30BEAE03E54BD36F257A925 /* ToolFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5774429CCE83C2AFBE046C /* ToolFilterView.swift */; };
@@ -72,8 +74,10 @@
 		C9AFE1AF02B0F8057791C2A9 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWatcher.swift; sourceTree = "<group>"; };
 		D57F2C41F08F6E1BEFC5ADD4 /* HighlightrSyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightrSyntaxHighlighter.swift; sourceTree = "<group>"; };
+		D5D3C2567FBF8DBA4DE957B3 /* DiagnosticExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticExporter.swift; sourceTree = "<group>"; };
 		E6A5B26D335C1AFB6CDE8207 /* SkillScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillScanner.swift; sourceTree = "<group>"; };
 		F02A00F80E4712872205EA7B /* NewSkillSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSkillSheet.swift; sourceTree = "<group>"; };
+		F45D5C8E8C732B2F4A867E43 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +139,7 @@
 		40FF74A5B2D0A1E16B14B7A4 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				D5D3C2567FBF8DBA4DE957B3 /* DiagnosticExporter.swift */,
 				A924245DDDA4C6A59BE15567 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -164,6 +169,7 @@
 		665294B304954CDCE458E2FA /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F45D5C8E8C732B2F4A867E43 /* AppLogger.swift */,
 				CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */,
 				7FFC47BDE92105F4736B379F /* SearchService.swift */,
 				5155D141EF812A3FE9ADF59C /* SkillParser.swift */,
@@ -301,11 +307,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				FD8D2544AE423F4AB2843C0F /* AgentTarget.swift in Sources */,
+				A99BA179E0520DCDC98E1382 /* AppLogger.swift in Sources */,
 				25A4FB387DB5BD96DB630C14 /* AppState.swift in Sources */,
 				309B12E0B72A22C9772BBC99 /* ChopsApp.swift in Sources */,
 				7A17C99C5EFAE3AA9E788D50 /* Collection.swift in Sources */,
 				7EC6156934D559226BC78859 /* CollectionListView.swift in Sources */,
 				D4C107BE303FC07CAF9C66AF /* ContentView.swift in Sources */,
+				AFDC3DAB708B352A7606F119 /* DiagnosticExporter.swift in Sources */,
 				99EE8F6124FE91AC9576D6FD /* FileWatcher.swift in Sources */,
 				CBD8FECF1C5A453C8B021665 /* FrontmatterParser.swift in Sources */,
 				9ED88D6237B36693ABE5CE85 /* HighlightrSyntaxHighlighter.swift in Sources */,

--- a/Chops/App/ChopsApp.swift
+++ b/Chops/App/ChopsApp.swift
@@ -49,6 +49,12 @@ struct ChopsApp: App {
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updaterController.updater)
             }
+            CommandGroup(after: .help) {
+                Button("Export Diagnostic Log…") {
+                    let context = sharedModelContainer.mainContext
+                    DiagnosticExporter.export(modelContext: context)
+                }
+            }
         }
 
         Settings {

--- a/Chops/App/ContentView.swift
+++ b/Chops/App/ContentView.swift
@@ -63,6 +63,7 @@ struct ContentView: View {
     }
 
     private func startScanning() {
+        AppLogger.ui.notice("App started, beginning initial scan")
         let scanner = SkillScanner(modelContext: modelContext)
         self.scanner = scanner
         scanner.scanAll()
@@ -78,5 +79,6 @@ struct ContentView: View {
         }
         watcher.watchDirectories(allPaths)
         self.fileWatcher = watcher
+        AppLogger.ui.notice("File watchers active on \(allPaths.count) directories")
     }
 }

--- a/Chops/Services/AppLogger.swift
+++ b/Chops/Services/AppLogger.swift
@@ -1,0 +1,10 @@
+import Foundation
+import os
+
+enum AppLogger {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "com.shpigford.Chops"
+
+    static let scanning = Logger(subsystem: subsystem, category: "scanning")
+    static let fileIO = Logger(subsystem: subsystem, category: "fileIO")
+    static let ui = Logger(subsystem: subsystem, category: "ui")
+}

--- a/Chops/Services/FileWatcher.swift
+++ b/Chops/Services/FileWatcher.swift
@@ -1,9 +1,12 @@
 import Foundation
+import os
 
 final class FileWatcher {
     private var sources: [DispatchSourceFileSystemObject] = []
     private var fileDescriptors: [Int32] = []
     private let callback: (String) -> Void
+    private let queue = DispatchQueue(label: "com.shpigford.Chops.filewatcher", qos: .utility)
+    private var debounceWorkItem: DispatchWorkItem?
 
     init(callback: @escaping (String) -> Void) {
         self.callback = callback
@@ -19,17 +22,22 @@ final class FileWatcher {
 
     private func watchDirectory(_ path: String) {
         let fd = open(path, O_EVTONLY)
-        guard fd >= 0 else { return }
+        guard fd >= 0 else {
+            AppLogger.fileIO.warning("Failed to watch: \(path)")
+            return
+        }
         fileDescriptors.append(fd)
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
             eventMask: [.write, .rename, .delete, .extend],
-            queue: .main
+            queue: queue
         )
 
         source.setEventHandler { [weak self] in
-            self?.callback(path)
+            guard let self else { return }
+            AppLogger.fileIO.debug("File change detected: \(path)")
+            self.debouncedCallback(path)
         }
 
         source.setCancelHandler {
@@ -40,7 +48,20 @@ final class FileWatcher {
         sources.append(source)
     }
 
+    private func debouncedCallback(_ path: String) {
+        debounceWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            AppLogger.fileIO.notice("Triggering rescan after debounce")
+            DispatchQueue.main.async {
+                self?.callback(path)
+            }
+        }
+        debounceWorkItem = work
+        queue.asyncAfter(deadline: .now() + 0.5, execute: work)
+    }
+
     func stopAll() {
+        debounceWorkItem?.cancel()
         for source in sources {
             source.cancel()
         }

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -1,9 +1,27 @@
 import Foundation
 import SwiftData
+import os
+
+/// Data collected from the filesystem for a single skill, before SwiftData persistence.
+struct ScannedSkillData: Sendable {
+    let fileURL: URL
+    let resolvedPath: String
+    let toolSource: ToolSource
+    let isDirectory: Bool
+    let isGlobal: Bool
+    let name: String
+    let skillDescription: String
+    let content: String
+    let frontmatter: [String: String]
+    let modDate: Date
+    let fileSize: Int
+}
 
 @Observable
 final class SkillScanner {
     private let modelContext: ModelContext
+    private var scanTask: Task<Void, Never>?
+    private var scanGeneration = 0
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
@@ -21,18 +39,49 @@ final class SkillScanner {
     ]
 
     func scanAll() {
-        for tool in ToolSource.allCases where tool != .custom {
-            scanTool(tool)
-        }
+        let start = CFAbsoluteTimeGetCurrent()
+        AppLogger.scanning.notice("Scan started")
+
+        scanTask?.cancel()
+        scanGeneration += 1
+        let generation = scanGeneration
         let customPaths = UserDefaults.standard.stringArray(forKey: "customScanPaths") ?? []
-        for path in customPaths {
-            scanCustomDirectory(URL(fileURLWithPath: path))
+        scanTask = Task.detached { [weak self] in
+            let results = Self.collectAllSkills(customPaths: customPaths)
+            guard !Task.isCancelled else { return }
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            AppLogger.scanning.notice("File collection done: \(results.count) skills in \(String(format: "%.2f", elapsed))s")
+
+            await MainActor.run {
+                guard let self, self.scanGeneration == generation else { return }
+                self.applyResults(results)
+                let total = CFAbsoluteTimeGetCurrent() - start
+                AppLogger.scanning.notice("Scan complete: \(results.count) skills applied in \(String(format: "%.2f", total))s")
+            }
         }
     }
 
-    /// Scans a custom directory by iterating its subdirectories (projects)
-    /// and probing each for tool-specific skill locations.
-    private func scanCustomDirectory(_ directory: URL) {
+    /// Pure filesystem I/O — safe to run off main thread.
+    private static func collectAllSkills(customPaths: [String]) -> [ScannedSkillData] {
+        var results: [ScannedSkillData] = []
+
+        for tool in ToolSource.allCases where tool != .custom {
+            guard !Task.isCancelled else { return results }
+            for path in tool.globalPaths {
+                let url = URL(fileURLWithPath: path)
+                collectFromDirectory(url, toolSource: tool, isGlobal: true, into: &results)
+            }
+        }
+
+        for path in customPaths {
+            guard !Task.isCancelled else { return results }
+            collectFromCustomDirectory(URL(fileURLWithPath: path), into: &results)
+        }
+
+        return results
+    }
+
+    private static func collectFromCustomDirectory(_ directory: URL, into results: inout [ScannedSkillData]) {
         let fm = FileManager.default
         guard let projects = try? fm.contentsOfDirectory(
             at: directory,
@@ -41,35 +90,30 @@ final class SkillScanner {
         ) else { return }
 
         for project in projects {
+            guard !Task.isCancelled else { return }
             var isDir: ObjCBool = false
             fm.fileExists(atPath: project.path, isDirectory: &isDir)
             guard isDir.boolValue else { continue }
 
-            for probe in Self.projectProbes {
+            for probe in projectProbes {
                 let probePath = project.appendingPathComponent(probe.subpath)
                 guard fm.fileExists(atPath: probePath.path) else { continue }
 
                 if probe.tool == .copilot {
-                    // Copilot: single file
                     let file = probePath.appendingPathComponent("copilot-instructions.md")
                     if fm.fileExists(atPath: file.path) {
-                        upsertSkill(at: file, toolSource: .copilot, isDirectory: false, isGlobal: false)
+                        if let data = collectSkillData(at: file, toolSource: .copilot, isDirectory: false, isGlobal: false) {
+                            results.append(data)
+                        }
                     }
                 } else {
-                    scanDirectory(probePath, toolSource: probe.tool, isGlobal: false)
+                    collectFromDirectory(probePath, toolSource: probe.tool, isGlobal: false, into: &results)
                 }
             }
         }
     }
 
-    func scanTool(_ tool: ToolSource) {
-        for path in tool.globalPaths {
-            let url = URL(fileURLWithPath: path)
-            scanDirectory(url, toolSource: tool, isGlobal: true)
-        }
-    }
-
-    private func scanDirectory(_ directory: URL, toolSource: ToolSource, isGlobal: Bool = true) {
+    private static func collectFromDirectory(_ directory: URL, toolSource: ToolSource, isGlobal: Bool, into results: inout [ScannedSkillData]) {
         let fm = FileManager.default
 
         var isDir: ObjCBool = false
@@ -79,10 +123,10 @@ final class SkillScanner {
         if toolSource == .codex || toolSource == .amp {
             let agentsMD = directory.appendingPathComponent("AGENTS.md")
             if fm.fileExists(atPath: agentsMD.path) {
-                upsertSkill(at: agentsMD, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal)
+                if let data = collectSkillData(at: agentsMD, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal) {
+                    results.append(data)
+                }
             }
-            // Scan subdirectories for skills (SKILL.md or AGENTS.md)
-            // The official skills CLI installs SKILL.md into subdirectories here
             let scanDirs = [directory, directory.appendingPathComponent("skills")]
             for scanDir in scanDirs {
                 guard let contents = try? fm.contentsOfDirectory(
@@ -97,9 +141,13 @@ final class SkillScanner {
                         let skillFile = item.appendingPathComponent("SKILL.md")
                         let agentsFile = item.appendingPathComponent("AGENTS.md")
                         if fm.fileExists(atPath: skillFile.path) {
-                            upsertSkill(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal)
+                            if let data = collectSkillData(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
+                                results.append(data)
+                            }
                         } else if fm.fileExists(atPath: agentsFile.path) {
-                            upsertSkill(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal)
+                            if let data = collectSkillData(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
+                                results.append(data)
+                            }
                         }
                     }
                 }
@@ -116,31 +164,40 @@ final class SkillScanner {
         ) else { return }
 
         for item in contents {
+            guard !Task.isCancelled else { return }
             var itemIsDir: ObjCBool = false
             fm.fileExists(atPath: item.path, isDirectory: &itemIsDir)
 
             if itemIsDir.boolValue {
-                // Directory-based skill — look for SKILL.md or AGENTS.md inside
                 let skillFile = item.appendingPathComponent("SKILL.md")
                 let agentsFile = item.appendingPathComponent("AGENTS.md")
 
                 if fm.fileExists(atPath: skillFile.path) {
-                    upsertSkill(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal)
+                    if let data = collectSkillData(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
+                        results.append(data)
+                    }
                 } else if fm.fileExists(atPath: agentsFile.path) {
-                    upsertSkill(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal)
+                    if let data = collectSkillData(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
+                        results.append(data)
+                    }
                 }
             } else if item.pathExtension == "md" || item.pathExtension == "mdc" {
-                upsertSkill(at: item, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal)
+                if let data = collectSkillData(at: item, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal) {
+                    results.append(data)
+                }
             }
         }
     }
 
-    private func upsertSkill(at fileURL: URL, toolSource: ToolSource, isDirectory: Bool, isGlobal: Bool = true) {
+    /// Read and parse a single skill file. Pure I/O, no SwiftData.
+    private static func collectSkillData(at fileURL: URL, toolSource: ToolSource, isDirectory: Bool, isGlobal: Bool) -> ScannedSkillData? {
         let fm = FileManager.default
-        let path = fileURL.path
         let resolved = fileURL.resolvingSymlinksInPath().path
 
-        guard let parsed = SkillParser.parse(fileURL: fileURL, toolSource: toolSource) else { return }
+        guard let parsed = SkillParser.parse(fileURL: fileURL, toolSource: toolSource) else {
+            AppLogger.scanning.warning("Failed to parse: \(fileURL.path)")
+            return nil
+        }
 
         let attrs = try? fm.attributesOfItem(atPath: resolved)
         let modDate = (attrs?[.modificationDate] as? Date) ?? .now
@@ -155,36 +212,54 @@ final class SkillScanner {
             name = fileURL.deletingPathExtension().lastPathComponent
         }
 
-        // Dedup: look up by resolved path first
-        let predicate = #Predicate<Skill> { $0.resolvedPath == resolved }
-        let descriptor = FetchDescriptor<Skill>(predicate: predicate)
+        return ScannedSkillData(
+            fileURL: fileURL,
+            resolvedPath: resolved,
+            toolSource: toolSource,
+            isDirectory: isDirectory,
+            isGlobal: isGlobal,
+            name: name,
+            skillDescription: parsed.description,
+            content: parsed.content,
+            frontmatter: parsed.frontmatter,
+            modDate: modDate,
+            fileSize: fileSize
+        )
+    }
 
-        if let existing = try? modelContext.fetch(descriptor).first {
-            // Same physical file — merge this tool/path into the existing entry
-            existing.content = parsed.content
-            existing.name = name
-            existing.skillDescription = parsed.description
-            existing.frontmatter = parsed.frontmatter
-            existing.fileModifiedDate = modDate
-            existing.fileSize = fileSize
-            existing.addInstallation(path: path, tool: toolSource)
-        } else {
-            let skill = Skill(
-                filePath: path,
-                toolSource: toolSource,
-                isDirectory: isDirectory,
-                name: name,
-                skillDescription: parsed.description,
-                content: parsed.content,
-                frontmatter: parsed.frontmatter,
-                fileModifiedDate: modDate,
-                fileSize: fileSize,
-                isGlobal: isGlobal,
-                resolvedPath: resolved
-            )
-            modelContext.insert(skill)
+    /// Apply collected results to SwiftData. Must be called on main thread.
+    @MainActor
+    private func applyResults(_ results: [ScannedSkillData]) {
+        for data in results {
+            let resolved = data.resolvedPath
+            let predicate = #Predicate<Skill> { $0.resolvedPath == resolved }
+            let descriptor = FetchDescriptor<Skill>(predicate: predicate)
+
+            if let existing = try? modelContext.fetch(descriptor).first {
+                existing.content = data.content
+                existing.name = data.name
+                existing.skillDescription = data.skillDescription
+                existing.frontmatter = data.frontmatter
+                existing.fileModifiedDate = data.modDate
+                existing.fileSize = data.fileSize
+                existing.addInstallation(path: data.fileURL.path, tool: data.toolSource)
+            } else {
+                let skill = Skill(
+                    filePath: data.fileURL.path,
+                    toolSource: data.toolSource,
+                    isDirectory: data.isDirectory,
+                    name: data.name,
+                    skillDescription: data.skillDescription,
+                    content: data.content,
+                    frontmatter: data.frontmatter,
+                    fileModifiedDate: data.modDate,
+                    fileSize: data.fileSize,
+                    isGlobal: data.isGlobal,
+                    resolvedPath: data.resolvedPath
+                )
+                modelContext.insert(skill)
+            }
         }
-
         try? modelContext.save()
     }
 
@@ -194,18 +269,20 @@ final class SkillScanner {
         let fm = FileManager.default
 
         for skill in skills {
-            // Remove paths that no longer exist
             let validPaths = skill.installedPaths.filter { fm.fileExists(atPath: $0) }
             if validPaths.isEmpty {
                 modelContext.delete(skill)
             } else {
                 skill.installedPaths = validPaths
-                // Update primary filePath if it was deleted
                 if !fm.fileExists(atPath: skill.filePath), let first = validPaths.first {
                     skill.filePath = first
                 }
             }
         }
         try? modelContext.save()
+    }
+
+    deinit {
+        scanTask?.cancel()
     }
 }

--- a/Chops/Views/Detail/SkillEditorView.swift
+++ b/Chops/Views/Detail/SkillEditorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import os
 
 @Observable
 final class SkillEditorDocument {
@@ -15,22 +16,41 @@ final class SkillEditorDocument {
 
     private var fullFileContent: String = ""
     private var isLoading = false
+    private var loadTask: Task<Void, Never>?
+    private var loadGeneration = 0
 
     func load(from skill: Skill) {
         isLoading = true
+        loadTask?.cancel()
+        loadGeneration += 1
 
-        if let data = try? String(contentsOfFile: skill.filePath, encoding: .utf8) {
-            editorContent = data
-            fullFileContent = data
-        } else {
-            editorContent = skill.content
-            fullFileContent = skill.content
+        let path = skill.filePath
+        let fallback = skill.content
+        let generation = loadGeneration
+
+        loadTask = Task.detached { [weak self] in
+            let start = CFAbsoluteTimeGetCurrent()
+            let data: String
+            if let fileData = try? String(contentsOfFile: path, encoding: .utf8) {
+                data = fileData
+            } else {
+                AppLogger.fileIO.warning("Failed to read file, using cached content: \(path)")
+                data = fallback
+            }
+            guard !Task.isCancelled else { return }
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            AppLogger.fileIO.notice("Loaded \(path) in \(String(format: "%.3f", elapsed))s (\(data.count) chars)")
+
+            await MainActor.run { [data] in
+                guard let self, self.loadGeneration == generation else { return }
+                self.editorContent = data
+                self.fullFileContent = data
+                self.isLoading = false
+                self.hasUnsavedChanges = false
+                self.showingSaveError = false
+                self.saveErrorMessage = ""
+            }
         }
-
-        isLoading = false
-        hasUnsavedChanges = false
-        showingSaveError = false
-        saveErrorMessage = ""
     }
 
     func save(to skill: Skill) {
@@ -50,10 +70,16 @@ final class SkillEditorDocument {
             let attrs = try? FileManager.default.attributesOfItem(atPath: skill.filePath)
             skill.fileModifiedDate = (attrs?[.modificationDate] as? Date) ?? skill.fileModifiedDate
             skill.fileSize = (attrs?[.size] as? Int) ?? skill.fileSize
+            AppLogger.fileIO.info("Saved: \(skill.filePath)")
         } catch {
+            AppLogger.fileIO.error("Save failed: \(error.localizedDescription)")
             saveErrorMessage = error.localizedDescription
             showingSaveError = true
         }
+    }
+
+    deinit {
+        loadTask?.cancel()
     }
 }
 

--- a/Chops/Views/Settings/DiagnosticExporter.swift
+++ b/Chops/Views/Settings/DiagnosticExporter.swift
@@ -1,0 +1,109 @@
+import AppKit
+import Foundation
+import OSLog
+import SwiftData
+
+enum DiagnosticExporter {
+    static func export(modelContext: ModelContext) {
+        var lines: [String] = []
+
+        // System info
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+
+        lines.append("# Chops Diagnostic Report")
+        lines.append("Generated: \(ISO8601DateFormatter().string(from: .now))")
+        lines.append("")
+        lines.append("## System")
+        lines.append("- App Version: \(version) (\(build))")
+        lines.append("- macOS: \(osVersion)")
+        lines.append("- Memory: \(ProcessInfo.processInfo.physicalMemory / 1_073_741_824) GB")
+        lines.append("")
+
+        // Skill counts
+        let descriptor = FetchDescriptor<Skill>()
+        let skills = (try? modelContext.fetch(descriptor)) ?? []
+        lines.append("## Skills")
+        lines.append("- Total: \(skills.count)")
+        for tool in ToolSource.allCases {
+            let count = skills.filter { $0.toolSources.contains(tool) }.count
+            if count > 0 {
+                lines.append("- \(tool.displayName): \(count)")
+            }
+        }
+        lines.append("")
+
+        // Custom scan paths
+        let customPaths = UserDefaults.standard.stringArray(forKey: "customScanPaths") ?? []
+        lines.append("## Custom Scan Paths")
+        if customPaths.isEmpty {
+            lines.append("- (none)")
+        } else {
+            for path in customPaths {
+                lines.append("- \(path)")
+            }
+        }
+        lines.append("")
+
+        // Recent logs
+        lines.append("## Recent Logs")
+        if let logEntries = collectRecentLogs() {
+            lines.append(logEntries)
+        } else {
+            lines.append("(Unable to collect logs)")
+        }
+
+        let report = lines.joined(separator: "\n")
+
+        // Save panel
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "chops-diagnostic-\(dateStamp()).txt"
+        panel.allowedContentTypes = [.plainText]
+
+        if panel.runModal() == .OK, let url = panel.url {
+            try? report.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private static func collectRecentLogs() -> String? {
+        // Try system scope first (persisted logs, survives force quit)
+        // Fall back to current process scope
+        let store: OSLogStore
+        if let systemStore = try? OSLogStore(scope: .system) {
+            store = systemStore
+        } else if let processStore = try? OSLogStore(scope: .currentProcessIdentifier) {
+            store = processStore
+        } else {
+            return nil
+        }
+
+        let since = Date.now.addingTimeInterval(-3600) // last hour
+        let subsystem = Bundle.main.bundleIdentifier ?? "com.shpigford.Chops"
+
+        guard let entries = try? store.getEntries(
+            at: store.position(date: since),
+            matching: NSPredicate(format: "subsystem == %@", subsystem)
+        ) else {
+            return nil
+        }
+
+        var lines: [String] = []
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+
+        for entry in entries {
+            guard let logEntry = entry as? OSLogEntryLog else { continue }
+            let time = formatter.string(from: logEntry.date)
+            lines.append("[\(time)] [\(logEntry.category)] \(logEntry.composedMessage)")
+        }
+
+        return lines.isEmpty ? "(No log entries in the last hour)" : lines.joined(separator: "\n")
+    }
+
+    private static func dateStamp() -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd-HHmmss"
+        return f.string(from: .now)
+    }
+}


### PR DESCRIPTION
## Summary

- Moves all file I/O off the main thread to fix UI freezes reported on macOS Sequoia — scanning, file watching, and skill loading now run on background threads with results applied on main
- Adds `os.Logger`-based diagnostic logging throughout scanning, file I/O, and UI lifecycle with `.notice` level for persistence
- Adds Help → "Export Diagnostic Log…" menu item that collects system info, skill counts, and recent logs via `OSLogStore` into a saveable text file for remote debugging
- FileWatcher now uses a background dispatch queue with 0.5s debounce instead of firing every event directly on `.main`

## Test plan
- [ ] Build and launch — verify no compile errors
- [ ] Select skills rapidly — confirm no UI freezing
- [ ] Check Console.app for structured logs under `com.joshpigford.Chops` subsystem
- [ ] Help → Export Diagnostic Log — verify it produces a readable report with logs and system info
- [ ] Modify a skill file externally — verify FileWatcher triggers rescan without freezing