### PR TITLE
Fix infinite SwiftUI layout loop when selecting a skill

### DIFF
--- a/Chops/App/ChopsApp.swift
+++ b/Chops/App/ChopsApp.swift
@@ -26,8 +26,6 @@ struct ChopsApp: App {
         }
     }()
 
-    @FocusedValue(\.saveAction) var saveAction
-
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -37,10 +35,10 @@ struct ChopsApp: App {
         .commands {
             CommandGroup(replacing: .saveItem) {
                 Button("Save") {
-                    saveAction?.action()
+                    NotificationCenter.default.post(name: .saveCurrentSkill, object: nil)
                 }
                 .keyboardShortcut("s", modifiers: .command)
-                .disabled(saveAction == nil)
+                .disabled(appState.selectedSkill == nil)
             }
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updaterController.updater)

--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -44,7 +44,9 @@ struct SkillDetailView: View {
         .onChange(of: skill.filePath) {
             document.load(from: skill)
         }
-        .focusedValue(\.saveAction, SaveAction(action: { document.save(to: skill) }))
+        .onReceive(NotificationCenter.default.publisher(for: .saveCurrentSkill)) { _ in
+            document.save(to: skill)
+        }
         .alert("Save Error", isPresented: $document.showingSaveError) {
             Button("OK") {}
         } message: {

--- a/Chops/Views/Detail/SkillEditorView.swift
+++ b/Chops/Views/Detail/SkillEditorView.swift
@@ -225,21 +225,10 @@ struct SkillEditorView: View {
     }
 }
 
-// MARK: - Save Action via FocusedValues for Cmd+S menu support
+// MARK: - Save notification for Cmd+S menu support
 
-struct SaveAction {
-    let action: () -> Void
-}
-
-struct SaveActionKey: FocusedValueKey {
-    typealias Value = SaveAction
-}
-
-extension FocusedValues {
-    var saveAction: SaveAction? {
-        get { self[SaveActionKey.self] }
-        set { self[SaveActionKey.self] = newValue }
-    }
+extension Notification.Name {
+    static let saveCurrentSkill = Notification.Name("saveCurrentSkill")
 }
 
 // MARK: - Syntax-highlighted NSTextView wrapper
@@ -312,7 +301,6 @@ struct HighlightedTextEditor: NSViewRepresentable {
 enum MarkdownHighlighter {
     private static let muted = NSColor.secondaryLabelColor
     private static let faintBg = NSColor.quaternaryLabelColor
-
     static func highlight(_ textView: NSTextView) {
         let text = textView.string
         let fullRange = NSRange(location: 0, length: (text as NSString).length)


### PR DESCRIPTION
## Problem

The app freezes with a spinning cursor when clicking any skill in the list. The console shows:

> The window has been marked as needing another Update Constraints in Window pass, but it has already had more Update Constraints in Window passes than there are views in the window.

## Root Cause

`.focusedValue(\.saveAction, SaveAction(...))` in `SkillDetailView` creates a new `SaveAction` closure on every render. Since closures are not `Equatable`, SwiftUI treats the focused value as changed each time, triggering:

**toolbar update → layout pass → body re-evaluation → new SaveAction → infinite loop**

This happens immediately when selecting a skill (the SaveAction is never invoked — the loop is in the rendering cycle).

## Fix

Replace `focusedValue`/`FocusedValueKey` with `NotificationCenter` for the Cmd+S save action.

## Changes

- **ChopsApp.swift** — remove `@FocusedValue`, post `.saveCurrentSkill` notification instead, use `appState.selectedSkill == nil` for disabled state
- **SkillDetailView.swift** — `.focusedValue` → `.onReceive` notification
- **SkillEditorView.swift** — remove `SaveAction`/`SaveActionKey`/`FocusedValues` extension, add `Notification.Name` definition