### PR TITLE
Add Pi AI agent support

### DIFF
--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -9,6 +9,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
     case aider
     case amp
     case openclaw
+    case pi
     case custom
 
     var id: String { rawValue }
@@ -23,6 +24,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: "Aider"
         case .amp: "Amp"
         case .openclaw: "OpenClaw"
+        case .pi: "Pi"
         case .custom: "Custom"
         }
     }
@@ -38,6 +40,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: "wrench.and.screwdriver"
         case .amp: "bolt.fill"
         case .openclaw: "server.rack"
+        case .pi: "sparkles"
         case .custom: "folder"
         }
     }
@@ -64,6 +67,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: .yellow
         case .amp: .pink
         case .openclaw: .indigo
+        case .pi: .cyan
         case .custom: .gray
         }
     }
@@ -79,6 +83,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: return []
         case .amp: return ["\(home)/.config/amp"]
         case .openclaw: return []
+        case .pi: return ["\(home)/.pi/agent/skills"]
         case .custom: return []
         }
     }

--- a/Chops/Services/SkillParser.swift
+++ b/Chops/Services/SkillParser.swift
@@ -12,7 +12,7 @@ enum SkillParser {
                 return MDCParser.parse(content)
             }
             return FrontmatterParser.parse(content)
-        case .codex, .amp, .windsurf, .copilot, .aider, .openclaw, .custom:
+        case .codex, .amp, .windsurf, .copilot, .aider, .openclaw, .pi, .custom:
             // Try frontmatter first, fall back to heading
             let parsed = FrontmatterParser.parse(content)
             if !parsed.name.isEmpty { return parsed }

--- a/Chops/Views/Shared/ToolBadge.swift
+++ b/Chops/Views/Shared/ToolBadge.swift
@@ -44,6 +44,7 @@ extension ToolSource {
         case .aider: "AI"
         case .amp: "AM"
         case .openclaw: "OC"
+        case .pi: "PI"
         case .custom: "?"
         }
     }


### PR DESCRIPTION
## Summary

Add Pi AI agent as a supported tool in Chops with skill scanning from `~/.pi/agent/skills`.

## Changes

- **ToolSource.swift**: Added `.pi` case with display name, icon (sparkles SF Symbol), cyan color, and skill paths
- **SkillParser.swift**: Added `.pi` to frontmatter parser case
- **ToolBadge.swift**: Added "PI" shortLabel for metadata badge

The app now discovers and manages Pi agent skills alongside other supported tools.

## Testing

- [x] Build succeeds (LocalRelease configuration)
- [x] App launches without errors
- [x] Pi tool appears in tool filters/lists with correct styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)