### PR TITLE
Fix constraint recursion crash with 50+ skills

### DIFF
--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -228,14 +228,22 @@ final class SkillScanner {
     }
 
     /// Apply collected results to SwiftData. Must be called on main thread.
+    ///
+    /// All mutations are performed inside a single `withoutActuallyEscaping`-style
+    /// batch: we defer `save()` until the end so SwiftUI's `@Query` observers
+    /// coalesce into a single view update instead of firing once per insert.
     @MainActor
     private func applyResults(_ results: [ScannedSkillData]) {
-        for data in results {
-            let resolved = data.resolvedPath
-            let predicate = #Predicate<Skill> { $0.resolvedPath == resolved }
-            let descriptor = FetchDescriptor<Skill>(predicate: predicate)
+        // Pre-fetch all existing skills in one query to avoid N+1 fetches
+        let allDescriptor = FetchDescriptor<Skill>()
+        let existingSkills = (try? modelContext.fetch(allDescriptor)) ?? []
+        let existingByPath = Dictionary(uniqueKeysWithValues: existingSkills.map { ($0.resolvedPath, $0) })
 
-            if let existing = try? modelContext.fetch(descriptor).first {
+        modelContext.undoManager?.disableUndoRegistration()
+        defer { modelContext.undoManager?.enableUndoRegistration() }
+
+        for data in results {
+            if let existing = existingByPath[data.resolvedPath] {
                 existing.content = data.content
                 existing.name = data.name
                 existing.skillDescription = data.skillDescription

--- a/Chops/Views/Detail/SkillEditorView.swift
+++ b/Chops/Views/Detail/SkillEditorView.swift
@@ -269,6 +269,17 @@ struct HighlightedTextEditor: NSViewRepresentable {
         textView.textContainerInset = NSSize(width: 12, height: 12)
         textView.backgroundColor = .clear
 
+        // Prevent NSTextView's intrinsic content size from propagating up through
+        // the NavigationSplitView constraint chain. Without this, large documents
+        // trigger recursive _informContainerThatSubviewsNeedUpdateConstraints calls
+        // that crash AppKit's constraint solver.
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.heightTracksTextView = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+
         textView.delegate = context.coordinator
         context.coordinator.textView = textView
 
@@ -281,10 +292,17 @@ struct HighlightedTextEditor: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         let textView = scrollView.documentView as! NSTextView
         if textView.string != text {
-            let selectedRanges = textView.selectedRanges
-            textView.string = text
-            MarkdownHighlighter.highlight(textView)
-            textView.selectedRanges = selectedRanges
+            // Defer the text update to the next run loop tick so it doesn't
+            // overlap with SwiftUI's constraint update pass. This prevents the
+            // recursive _informContainerThatSubviewsNeedUpdateConstraints crash.
+            let newText = text
+            DispatchQueue.main.async {
+                guard textView.string != newText else { return }
+                let selectedRanges = textView.selectedRanges
+                textView.string = newText
+                MarkdownHighlighter.highlight(textView)
+                textView.selectedRanges = selectedRanges
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Chops v1.5.0 crashes on launch (EXC_BREAKPOINT / SIGTRAP) when scanning a large skill library (~54 skills). The crash is in AppKit's constraint solver:

```
-[NSWindow(NSDisplayCycle) _postWindowNeedsUpdateConstraints]
→ recursive _informContainerThatSubviewsNeedUpdateConstraints (12+ deep)
→ NSHostingView.updateConstraints
```

**Reproduction:** Install 50+ Claude Code skills in `~/.claude/skills/`, launch Chops. Crash occurs ~60-80 seconds after launch when the initial scan completes.

**Environment:** macOS 15.7.2 (Sequoia), Mac Mini M4 16GB, SwiftUI 6.5.4

## Root Cause

`applyResults()` inserts/updates SwiftData records in a tight loop with N+1 fetches (one `FetchDescriptor` per skill). Each mutation triggers `@Query` re-evaluation across three views (`SidebarView`, `SkillListView`, `ContentView`), which invalidates the `NavigationSplitView`'s three-column layout. The constraint updates propagate recursively through deeply nested SwiftUI hosting views until AppKit throws.

The `HighlightedTextEditor` (NSViewRepresentable) amplifies this because NSTextView's intrinsic content size participates in the constraint chain.

## Fixes

### 1. Batch SwiftData mutations (`SkillScanner.swift`)
- Pre-fetch all existing skills in one query → dictionary lookup (eliminates N+1)
- Disable undo registration during bulk update so `@Query` observers coalesce into a single view update on `save()`

### 2. Stabilize NSTextView constraints (`SkillEditorView.swift`)
- Explicitly configure text container sizing (`widthTracksTextView=true`, `heightTracksTextView=false`)
- Set scroll view scroller configuration to prevent intrinsic size propagation through the NavigationSplitView constraint chain

### 3. Defer text updates in `updateNSView`
- Dispatch text replacement to the next run loop tick so it doesn't overlap with SwiftUI's constraint update pass

## Testing

Unable to build locally (only have Command Line Tools, not Xcode.app). Crash analysis and fix are based on the crash report backtrace and code review. The three changes are independently safe — each addresses a different layer of the constraint propagation chain.

---

Full crash report available on request. Diagnosed via backtrace analysis of the `EXC_BREAKPOINT` in `-[NSApplication _crashOnException:]`.