### PR TITLE
Fix Sparkle minimum macOS version from 26.0 to 15.0

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -215,7 +215,7 @@ cat > build/appcast.xml << APPCAST
       <title>Version $VERSION</title>
       <sparkle:version>$VERSION</sparkle:version>
       <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>$PUB_DATE</pubDate>
 $DESC_ELEMENT
       <enclosure

--- a/site/public/appcast.xml
+++ b/site/public/appcast.xml
@@ -6,7 +6,7 @@
       <title>Version 1.6.0</title>
       <sparkle:version>1.6.0</sparkle:version>
       <sparkle:shortVersionString>1.6.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>Sun, 22 Mar 2026 21:29:20 +0000</pubDate>
       <description><![CDATA[<ul><li>Fix layout freeze when selecting a skill</li><li>Press Enter to quickly create new collections</li><li>Rename collections from the right-click menu</li></ul>]]></description>
       <enclosure
@@ -20,7 +20,7 @@
       <title>Version 1.5.0</title>
       <sparkle:version>1.5.0</sparkle:version>
       <sparkle:shortVersionString>1.5.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>Sat, 21 Mar 2026 17:17:31 +0000</pubDate>
       <description><![CDATA[<ul><li>Connect to remote servers (such as OpenClaw) to discover, browse, and edit skills (@t2)</li></ul>]]></description>
       <enclosure
@@ -34,7 +34,7 @@
       <title>Version 1.4.0</title>
       <sparkle:version>1.4.0</sparkle:version>
       <sparkle:shortVersionString>1.4.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>Sat, 21 Mar 2026 15:26:57 +0000</pubDate>
       <description><![CDATA[<ul><li>Delete skills directly from the context menu or toolbar</li><li>Diagnostic logging and fixes for UI freezing</li></ul>]]></description>
       <enclosure
@@ -48,7 +48,7 @@
       <title>Version 1.3.0</title>
       <sparkle:version>1.3.0</sparkle:version>
       <sparkle:shortVersionString>1.3.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>Sat, 21 Mar 2026 12:59:53 +0000</pubDate>
       <description><![CDATA[<ul><li>Markdown preview mode with syntax highlighting in the skill editor</li></ul>]]></description>
       <enclosure
@@ -62,7 +62,7 @@
       <title>Version 1.2.0</title>
       <sparkle:version>1.2.0</sparkle:version>
       <sparkle:shortVersionString>1.2.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>Sat, 21 Mar 2026 12:00:18 +0000</pubDate>
       <description><![CDATA[<ul><li>Skills registry browser for discovering and installing community skills</li></ul>]]></description>
       <enclosure
@@ -76,7 +76,7 @@
       <title>Version 1.1.0</title>
       <sparkle:version>1.1.0</sparkle:version>
       <sparkle:shortVersionString>1.1.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>Thu, 19 Mar 2026 12:24:55 +0000</pubDate>
       <enclosure
         url="https://github.com/Shpigford/chops/releases/download/v1.1.0/Chops.dmg"


### PR DESCRIPTION
The appcast template in `release.sh` hardcoded `minimumSystemVersion` as `26.0` instead of `15.0`, causing Sparkle to tell users on macOS 15–25 that their OS is too old to update. This fixes the template and corrects all existing appcast entries so users can receive updates again.