### PR TITLE
Hide non-skill config files from All Skills view

### DIFF
--- a/Chops/Models/AgentTarget.swift
+++ b/Chops/Models/AgentTarget.swift
@@ -99,8 +99,8 @@ struct AgentTarget: Identifiable, Hashable {
             AgentTarget(
                 id: "amp",
                 displayName: "Amp",
-                globalSkillsDir: "\(configHome)/amp",
-                skillFileName: "AGENTS.md",
+                globalSkillsDir: "\(configHome)/amp/skills",
+                skillFileName: "SKILL.md",
                 evidencePaths: [
                     "\(configHome)/amp/config.json",
                     "\(configHome)/amp/settings.json",

--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -74,14 +74,20 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
 
     var globalPaths: [String] {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let configHome: String = {
+            if let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"], !xdg.isEmpty {
+                return xdg
+            }
+            return "\(home)/.config"
+        }()
         switch self {
         case .claude: return ["\(home)/.claude/skills", "\(home)/.agents/skills"]
         case .cursor: return ["\(home)/.cursor/skills", "\(home)/.cursor/rules"]
         case .windsurf: return ["\(home)/.codeium/windsurf/memories", "\(home)/.windsurf/rules"]
-        case .codex: return ["\(home)/.codex"]
+        case .codex: return ["\(home)/.codex/skills"]
         case .copilot: return []
         case .aider: return []
-        case .amp: return ["\(home)/.config/amp"]
+        case .amp: return ["\(configHome)/amp/skills"]
         case .openclaw: return []
         case .pi: return ["\(home)/.pi/agent/skills"]
         case .custom: return []

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -23,6 +23,25 @@ final class SkillScanner {
     private var scanTask: Task<Void, Never>?
     private var scanGeneration = 0
 
+    /// Filenames that are tool config/meta files, not skills.
+    private static let ignoredFileNames: Set<String> = [
+        "README.md",
+        "README",
+        "CLAUDE.md",
+        "AGENTS.md",
+        "AGENTS.override.md",
+        "global_rules.md",
+        "SYSTEM.md",
+        "APPEND_SYSTEM.md",
+        "LICENSE.md",
+        "LICENSE",
+        "CHANGELOG.md",
+    ]
+
+    private static func shouldIgnoreLooseMarkdownFile(named fileName: String) -> Bool {
+        return ignoredFileNames.contains(fileName)
+    }
+
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
     }
@@ -32,10 +51,10 @@ final class SkillScanner {
         (".claude/skills", .claude),
         (".cursor/skills", .cursor),
         (".cursor/rules", .cursor),
-        (".codex", .codex),
+        (".codex/skills", .codex),
         (".windsurf/rules", .windsurf),
         (".github", .copilot),
-        (".config/amp", .amp),
+        (".config/amp/skills", .amp),
     ]
 
     func scanAll() {
@@ -119,42 +138,6 @@ final class SkillScanner {
         var isDir: ObjCBool = false
         guard fm.fileExists(atPath: directory.path, isDirectory: &isDir) else { return }
 
-        // Single-file tools like Codex: look for AGENTS.md directly in the directory
-        if toolSource == .codex || toolSource == .amp {
-            let agentsMD = directory.appendingPathComponent("AGENTS.md")
-            if fm.fileExists(atPath: agentsMD.path) {
-                if let data = collectSkillData(at: agentsMD, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal) {
-                    results.append(data)
-                }
-            }
-            let scanDirs = [directory, directory.appendingPathComponent("skills")]
-            for scanDir in scanDirs {
-                guard let contents = try? fm.contentsOfDirectory(
-                    at: scanDir,
-                    includingPropertiesForKeys: [.isDirectoryKey],
-                    options: [.skipsHiddenFiles]
-                ) else { continue }
-                for item in contents {
-                    var itemIsDir: ObjCBool = false
-                    fm.fileExists(atPath: item.path, isDirectory: &itemIsDir)
-                    if itemIsDir.boolValue {
-                        let skillFile = item.appendingPathComponent("SKILL.md")
-                        let agentsFile = item.appendingPathComponent("AGENTS.md")
-                        if fm.fileExists(atPath: skillFile.path) {
-                            if let data = collectSkillData(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
-                                results.append(data)
-                            }
-                        } else if fm.fileExists(atPath: agentsFile.path) {
-                            if let data = collectSkillData(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
-                                results.append(data)
-                            }
-                        }
-                    }
-                }
-            }
-            return
-        }
-
         guard isDir.boolValue else { return }
 
         guard let contents = try? fm.contentsOfDirectory(
@@ -182,6 +165,7 @@ final class SkillScanner {
                     }
                 }
             } else if item.pathExtension == "md" || item.pathExtension == "mdc" {
+                guard !shouldIgnoreLooseMarkdownFile(named: item.lastPathComponent) else { continue }
                 if let data = collectSkillData(at: item, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal) {
                     results.append(data)
                 }
@@ -355,6 +339,14 @@ final class SkillScanner {
 
             // Remote skills are managed by scanRemoteServer(), skip here
             if skill.isRemote { continue }
+
+            // Remove previously-scanned loose markdown files that are now filtered out.
+            let fileName = URL(fileURLWithPath: skill.filePath).lastPathComponent
+            if !skill.isDirectory, Self.shouldIgnoreLooseMarkdownFile(named: fileName) {
+                modelContext.delete(skill)
+                continue
+            }
+
             let validPaths = skill.installedPaths.filter { fm.fileExists(atPath: $0) }
             if validPaths.isEmpty {
                 modelContext.delete(skill)

--- a/Chops/Views/Shared/NewSkillSheet.swift
+++ b/Chops/Views/Shared/NewSkillSheet.swift
@@ -55,6 +55,12 @@ struct NewSkillSheet: View {
 
     private func createSkill() {
         let fm = FileManager.default
+        let configHome: String = {
+            if let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"], !xdg.isEmpty {
+                return xdg
+            }
+            return "\(fm.homeDirectoryForCurrentUser.path)/.config"
+        }()
         let sanitizedName = skillName
             .lowercased()
             .replacingOccurrences(of: " ", with: "-")
@@ -79,13 +85,17 @@ struct NewSkillSheet: View {
             fileName = "SKILL.md"
             isDirectory = true
         case .codex:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.codex"
-            fileName = "AGENTS.md"
-            isDirectory = false
+            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.codex/skills/\(sanitizedName)"
+            fileName = "SKILL.md"
+            isDirectory = true
         case .amp:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.config/amp"
-            fileName = "AGENTS.md"
-            isDirectory = false
+            basePath = "\(configHome)/amp/skills/\(sanitizedName)"
+            fileName = "SKILL.md"
+            isDirectory = true
+        case .pi:
+            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.pi/agent/skills/\(sanitizedName)"
+            fileName = "SKILL.md"
+            isDirectory = true
         default:
             let firstPath = selectedTool.globalPaths.first ?? "\(fm.homeDirectoryForCurrentUser.path)/.claude/skills/\(sanitizedName)"
             basePath = firstPath
@@ -155,8 +165,13 @@ struct NewSkillSheet: View {
 
             Add your skill instructions here.
             """
-        case .codex, .amp:
+        case .codex, .amp, .pi:
             return """
+            ---
+            name: \(name.lowercased().replacingOccurrences(of: " ", with: "-"))
+            description: \(name)
+            ---
+
             # \(name)
 
             ## Instructions


### PR DESCRIPTION
## Summary
- Adds a blocklist of well-known tool config/meta filenames (README.md, CLAUDE.md, AGENTS.md, global_rules.md, LICENSE.md, CHANGELOG.md, etc.) that are skipped during skill scanning
- Narrows Codex and Amp scan paths to their `skills/` subdirectories instead of scanning root config dirs, preventing root-level AGENTS.md from appearing
- Updates NewSkillSheet to create new skills in the correct locations for Codex, Amp, and Pi
- Cleans up previously-scanned non-skill records from SwiftData on next launch

Fixes #36