### PR TITLE
fix: hide tools that aren't installed from sidebar

### DIFF
--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -93,4 +93,60 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .custom: return []
         }
     }
+
+    /// Whether the tool is actually installed on this machine.
+    /// Checks for app bundles, CLI binaries, tool-specific config files,
+    /// or known global skill locations that imply a real setup is present.
+    var isInstalled: Bool {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+
+        switch self {
+        case .claude:
+            return fm.fileExists(atPath: "\(home)/.claude/settings.json")
+                || fm.fileExists(atPath: "\(home)/.claude/CLAUDE.md")
+                || fm.fileExists(atPath: "\(home)/.agents/skills")
+                || Self.cliBinaryExists("claude")
+        case .cursor:
+            return fm.fileExists(atPath: "/Applications/Cursor.app")
+                || fm.fileExists(atPath: "\(home)/.cursor/argv.json")
+        case .windsurf:
+            return fm.fileExists(atPath: "/Applications/Windsurf.app")
+                || fm.fileExists(atPath: "\(home)/.codeium/windsurf/argv.json")
+        case .codex:
+            return fm.fileExists(atPath: "\(home)/.codex/config.toml")
+                || fm.fileExists(atPath: "\(home)/.codex/auth.json")
+                || Self.cliBinaryExists("codex")
+        case .amp:
+            let configHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+                .flatMap { $0.isEmpty ? nil : $0 } ?? "\(home)/.config"
+            return fm.fileExists(atPath: "\(configHome)/amp/config.json")
+                || fm.fileExists(atPath: "\(configHome)/amp/settings.json")
+                || Self.cliBinaryExists("amp")
+        case .pi:
+            return Self.cliBinaryExists("pi")
+        case .copilot, .aider, .openclaw, .custom:
+            return true
+        }
+    }
+
+    private static func cliBinaryExists(_ name: String) -> Bool {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let paths = [
+            "/usr/local/bin/\(name)",
+            "/opt/homebrew/bin/\(name)",
+            "\(home)/.local/bin/\(name)",
+        ]
+        for path in paths where fm.fileExists(atPath: path) {
+            return true
+        }
+        let nvmDir = "\(home)/.nvm/versions/node"
+        if let nodeDirs = try? fm.contentsOfDirectory(atPath: nvmDir) {
+            for nodeDir in nodeDirs {
+                if fm.fileExists(atPath: "\(nvmDir)/\(nodeDir)/bin/\(name)") { return true }
+            }
+        }
+        return false
+    }
 }

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -86,6 +86,9 @@ final class SkillScanner {
 
         for tool in ToolSource.allCases where tool != .custom {
             guard !Task.isCancelled else { return results }
+            guard tool.isInstalled || tool.globalPaths.contains(where: { FileManager.default.fileExists(atPath: $0) }) else {
+                continue
+            }
             for path in tool.globalPaths {
                 let url = URL(fileURLWithPath: path)
                 collectFromDirectory(url, toolSource: tool, isGlobal: true, into: &results)


### PR DESCRIPTION
## Summary
- Adds `isInstalled` detection to `ToolSource` that checks for app bundles, CLI binaries, and tool-specific config files
- Prevents tools (e.g. Pi) from appearing in the sidebar when only a stale skills directory exists but the tool itself isn't installed
- Scanner skips scanning paths for tools that aren't installed and have no existing skill directories

## Test plan
- [ ] Build and launch the app
- [ ] Confirm tools you use (Claude Code, Cursor, Codex) still appear in the sidebar
- [ ] Confirm tools you don't use (Pi) no longer appear