### PR TITLE
feat: add OpenCode support

### DIFF
--- a/Chops/Models/AgentTarget.swift
+++ b/Chops/Models/AgentTarget.swift
@@ -18,10 +18,17 @@ struct AgentTarget: Identifiable, Hashable {
 
     var isInstalled: Bool {
         let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
 
         // Check for app bundle
-        if let app = appBundleName, fm.fileExists(atPath: "/Applications/\(app).app") {
-            return true
+        if let app = appBundleName {
+            let appPaths = [
+                "/Applications/\(app).app",
+                "\(home)/Applications/\(app).app",
+            ]
+            if appPaths.contains(where: { fm.fileExists(atPath: $0) }) {
+                return true
+            }
         }
 
         // Check for CLI binary
@@ -29,10 +36,10 @@ struct AgentTarget: Identifiable, Hashable {
             let searchPaths = [
                 "/usr/local/bin/\(cli)",
                 "/opt/homebrew/bin/\(cli)",
-                "\(fm.homeDirectoryForCurrentUser.path)/.local/bin/\(cli)",
+                "\(home)/.local/bin/\(cli)",
             ]
             // Also check nvm paths
-            let nvmDir = "\(fm.homeDirectoryForCurrentUser.path)/.nvm/versions/node"
+            let nvmDir = "\(home)/.nvm/versions/node"
             if let nodeDirs = try? fm.contentsOfDirectory(atPath: nvmDir) {
                 for nodeDir in nodeDirs {
                     let binPath = "\(nvmDir)/\(nodeDir)/bin/\(cli)"
@@ -107,6 +114,19 @@ struct AgentTarget: Identifiable, Hashable {
                 ],
                 appBundleName: nil,
                 cliBinaryName: "amp"
+            ),
+            AgentTarget(
+                id: "opencode",
+                displayName: "OpenCode",
+                globalSkillsDir: "\(configHome)/opencode/skills",
+                skillFileName: "SKILL.md",
+                evidencePaths: [
+                    "\(configHome)/opencode/opencode.json",
+                    "\(configHome)/opencode/opencode.jsonc",
+                    "\(home)/.local/share/opencode",
+                ],
+                appBundleName: "OpenCode",
+                cliBinaryName: "opencode"
             ),
             AgentTarget(
                 id: "goose",

--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -10,6 +10,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
     case aider
     case amp
     case openclaw
+    case opencode
     case pi
     case custom
 
@@ -25,6 +26,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: "Aider"
         case .amp: "Amp"
         case .openclaw: "OpenClaw"
+        case .opencode: "OpenCode"
         case .pi: "Pi"
         case .agents: "Global Agents"
         case .custom: "Custom"
@@ -42,6 +44,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: "wrench.and.screwdriver"
         case .amp: "bolt.fill"
         case .openclaw: "server.rack"
+        case .opencode: "terminal"
         case .pi: "sparkles"
         case .agents: "globe"
         case .custom: "folder"
@@ -57,6 +60,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .windsurf: "tool-windsurf"
         case .copilot: "tool-copilot"
         case .amp: "tool-amp"
+        case .opencode: "tool-opencode"
         default: nil
         }
     }
@@ -71,6 +75,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: .yellow
         case .amp: .pink
         case .openclaw: .indigo
+        case .opencode: .red
         case .pi: .cyan
         case .agents: .mint
         case .custom: .gray
@@ -94,6 +99,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .aider: return []
         case .amp: return ["\(configHome)/amp/skills"]
         case .openclaw: return []
+        case .opencode: return ["\(configHome)/opencode/skills"]
         case .pi: return ["\(home)/.pi/agent/skills"]
         case .agents: return ["\(home)/.agents/skills"]
         case .custom: return []
@@ -135,9 +141,27 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
                 || Self.cliBinaryExists("copilot")
         case .agents:
             return fm.fileExists(atPath: "\(home)/.agents/skills")
+        case .opencode:
+            let configHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+                .flatMap { $0.isEmpty ? nil : $0 } ?? "\(home)/.config"
+            return Self.appBundleExists("OpenCode")
+                || fm.fileExists(atPath: "\(configHome)/opencode/opencode.json")
+                || fm.fileExists(atPath: "\(configHome)/opencode/opencode.jsonc")
+                || fm.fileExists(atPath: "\(home)/.local/share/opencode")
+                || Self.cliBinaryExists("opencode")
         case .aider, .openclaw, .custom:
             return true
         }
+    }
+
+    private static func appBundleExists(_ name: String) -> Bool {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let paths = [
+            "/Applications/\(name).app",
+            "\(home)/Applications/\(name).app",
+        ]
+        return paths.contains { fm.fileExists(atPath: $0) }
     }
 
     private static func cliBinaryExists(_ name: String) -> Bool {

--- a/Chops/Resources/Assets.xcassets/tool-opencode.imageset/Contents.json
+++ b/Chops/Resources/Assets.xcassets/tool-opencode.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "logo.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Chops/Resources/Assets.xcassets/tool-opencode.imageset/logo.svg
+++ b/Chops/Resources/Assets.xcassets/tool-opencode.imageset/logo.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>opencode</title><path d="M16 6H8v12h8V6zm4 16H4V2h16v20z"></path></svg>

--- a/Chops/Services/SkillParser.swift
+++ b/Chops/Services/SkillParser.swift
@@ -12,7 +12,7 @@ enum SkillParser {
                 return MDCParser.parse(content)
             }
             return FrontmatterParser.parse(content)
-        case .codex, .amp, .windsurf, .copilot, .aider, .openclaw, .pi, .agents, .custom:
+        case .codex, .amp, .windsurf, .copilot, .aider, .openclaw, .opencode, .pi, .agents, .custom:
             // Try frontmatter first, fall back to heading
             let parsed = FrontmatterParser.parse(content)
             if !parsed.name.isEmpty { return parsed }

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -55,6 +55,7 @@ final class SkillScanner {
         (".windsurf/rules", .windsurf),
         (".github", .copilot),
         (".config/amp/skills", .amp),
+        (".opencode/skills", .opencode),
     ]
 
     func scanAll() {
@@ -217,36 +218,60 @@ final class SkillScanner {
     /// Apply collected results to SwiftData. Must be called on main thread.
     @MainActor
     private func applyResults(_ results: [ScannedSkillData]) {
-        for data in results {
-            let resolved = data.resolvedPath
-            let predicate = #Predicate<Skill> { $0.resolvedPath == resolved }
-            let descriptor = FetchDescriptor<Skill>(predicate: predicate)
+        let groupedResults = Dictionary(grouping: results, by: \.resolvedPath)
+        let descriptor = FetchDescriptor<Skill>()
+        let allSkills = (try? modelContext.fetch(descriptor)) ?? []
+        let localSkills = allSkills.filter { !$0.isRemote }
+        let existingByResolved = Dictionary(uniqueKeysWithValues: localSkills.map { ($0.resolvedPath, $0) })
+        let scannedResolvedPaths = Set(groupedResults.keys)
 
-            if let existing = try? modelContext.fetch(descriptor).first {
-                existing.content = data.content
-                existing.name = data.name
-                existing.skillDescription = data.skillDescription
-                existing.frontmatter = data.frontmatter
-                existing.fileModifiedDate = data.modDate
-                existing.fileSize = data.fileSize
-                existing.addInstallation(path: data.fileURL.path, tool: data.toolSource)
+        for (resolvedPath, installations) in groupedResults {
+            guard let primary = installations.first else { continue }
+
+            let installedPaths = Array(Set(installations.map(\.fileURL.path))).sorted()
+            let toolSources = ToolSource.allCases.filter { tool in
+                installations.contains { $0.toolSource == tool }
+            }
+
+            if let existing = existingByResolved[resolvedPath] {
+                let preferredPath = installedPaths.contains(existing.filePath) ? existing.filePath : primary.fileURL.path
+                let preferredData = installations.first(where: { $0.fileURL.path == preferredPath }) ?? primary
+
+                existing.filePath = preferredPath
+                existing.isDirectory = preferredData.isDirectory
+                existing.name = preferredData.name
+                existing.skillDescription = preferredData.skillDescription
+                existing.content = preferredData.content
+                existing.frontmatter = preferredData.frontmatter
+                existing.fileModifiedDate = preferredData.modDate
+                existing.fileSize = preferredData.fileSize
+                existing.isGlobal = preferredData.isGlobal
+                existing.installedPaths = installedPaths
+                existing.toolSources = toolSources
             } else {
                 let skill = Skill(
-                    filePath: data.fileURL.path,
-                    toolSource: data.toolSource,
-                    isDirectory: data.isDirectory,
-                    name: data.name,
-                    skillDescription: data.skillDescription,
-                    content: data.content,
-                    frontmatter: data.frontmatter,
-                    fileModifiedDate: data.modDate,
-                    fileSize: data.fileSize,
-                    isGlobal: data.isGlobal,
-                    resolvedPath: data.resolvedPath
+                    filePath: primary.fileURL.path,
+                    toolSource: primary.toolSource,
+                    isDirectory: primary.isDirectory,
+                    name: primary.name,
+                    skillDescription: primary.skillDescription,
+                    content: primary.content,
+                    frontmatter: primary.frontmatter,
+                    fileModifiedDate: primary.modDate,
+                    fileSize: primary.fileSize,
+                    isGlobal: primary.isGlobal,
+                    resolvedPath: primary.resolvedPath
                 )
+                skill.installedPaths = installedPaths
+                skill.toolSources = toolSources
                 modelContext.insert(skill)
             }
         }
+
+        for skill in localSkills where !scannedResolvedPaths.contains(skill.resolvedPath) {
+            modelContext.delete(skill)
+        }
+
         try? modelContext.save()
     }
 

--- a/Chops/Views/Detail/SkillMetadataBar.swift
+++ b/Chops/Views/Detail/SkillMetadataBar.swift
@@ -30,7 +30,7 @@ struct SkillMetadataBar: View {
                 Divider().frame(height: 16)
             }
 
-            Text(skill.isRemote ? (skill.remotePath ?? "") : abbreviatedPath)
+            Text(skill.isRemote ? (skill.remotePath ?? "") : displayPath)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -68,7 +68,13 @@ struct SkillMetadataBar: View {
         .background(.bar)
     }
 
-    private var abbreviatedPath: String {
+    private var displayPath: String {
+        let additionalCount = max(0, displayInstalledPaths.count - 1)
+        let suffix = additionalCount > 0 ? " (+\(additionalCount))" : ""
+        return abbreviatedFilePath + suffix
+    }
+
+    private var abbreviatedFilePath: String {
         skill.filePath.replacingOccurrences(
             of: FileManager.default.homeDirectoryForCurrentUser.path,
             with: "~"
@@ -80,10 +86,16 @@ struct SkillMetadataBar: View {
     }
 
     private var installedPathsSummary: String {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return skill.installedPaths
-            .map { $0.replacingOccurrences(of: home, with: "~") }
+        displayInstalledPaths
+            .map { $0.replacingOccurrences(of: FileManager.default.homeDirectoryForCurrentUser.path, with: "~") }
             .joined(separator: "\n")
+    }
+
+    private var displayInstalledPaths: [String] {
+        let otherPaths = skill.installedPaths
+            .filter { $0 != skill.filePath }
+            .sorted()
+        return [skill.filePath] + otherPaths
     }
 
     private var collectionPickerContent: some View {

--- a/Chops/Views/Shared/NewSkillSheet.swift
+++ b/Chops/Views/Shared/NewSkillSheet.swift
@@ -9,7 +9,7 @@ struct NewSkillSheet: View {
     @State private var selectedTool: ToolSource = .claude
     @State private var errorMessage: String?
 
-    private let creatableTools: [ToolSource] = [.claude, .agents, .cursor, .codex, .amp, .pi]
+    private let creatableTools: [ToolSource] = [.claude, .agents, .cursor, .codex, .amp, .opencode, .pi]
 
     var body: some View {
         VStack(spacing: 20) {
@@ -98,6 +98,10 @@ struct NewSkillSheet: View {
             basePath = "\(configHome)/amp/skills/\(sanitizedName)"
             fileName = "SKILL.md"
             isDirectory = true
+        case .opencode:
+            basePath = "\(configHome)/opencode/skills/\(sanitizedName)"
+            fileName = "SKILL.md"
+            isDirectory = true
         case .pi:
             basePath = "\(fm.homeDirectoryForCurrentUser.path)/.pi/agent/skills/\(sanitizedName)"
             fileName = "SKILL.md"
@@ -124,7 +128,7 @@ struct NewSkillSheet: View {
                 return
             }
 
-            let boilerplate = generateBoilerplate(name: skillName, tool: selectedTool)
+            let boilerplate = generateBoilerplate(name: skillName, skillID: sanitizedName, tool: selectedTool)
             try boilerplate.write(toFile: filePath, atomically: true, encoding: .utf8)
 
             // Insert into SwiftData
@@ -152,12 +156,12 @@ struct NewSkillSheet: View {
         }
     }
 
-    private func generateBoilerplate(name: String, tool: ToolSource) -> String {
+    private func generateBoilerplate(name: String, skillID: String, tool: ToolSource) -> String {
         switch tool {
         case .claude, .cursor:
             return """
             ---
-            name: \(name.lowercased().replacingOccurrences(of: " ", with: "-"))
+            name: \(skillID)
             description: \(name)
             ---
 
@@ -171,10 +175,10 @@ struct NewSkillSheet: View {
 
             Add your skill instructions here.
             """
-        case .codex, .amp, .pi, .agents:
+        case .codex, .amp, .opencode, .pi, .agents:
             return """
             ---
-            name: \(name.lowercased().replacingOccurrences(of: " ", with: "-"))
+            name: \(skillID)
             description: \(name)
             ---
 
@@ -187,7 +191,7 @@ struct NewSkillSheet: View {
         default:
             return """
             ---
-            name: \(name.lowercased().replacingOccurrences(of: " ", with: "-"))
+            name: \(skillID)
             description: \(name)
             ---
 

--- a/Chops/Views/Shared/ToolBadge.swift
+++ b/Chops/Views/Shared/ToolBadge.swift
@@ -44,6 +44,7 @@ extension ToolSource {
         case .aider: "AI"
         case .amp: "AM"
         case .openclaw: "OC"
+        case .opencode: "OP"
         case .pi: "PI"
         case .agents: "AG"
         case .custom: "?"


### PR DESCRIPTION
## Summary
- Adds OpenCode (opencode.ai) as a supported tool source, scanning `~/.config/opencode/skills/` for SKILL.md files
- Includes SVG logo, installation detection (app bundle, config files, CLI binary), and skill creation support in the New Skill sheet
- Adds OpenCode as an agent target in AgentTarget.swift
- Refactors SkillScanner applyResults to batch-process by resolved path and bulk-delete orphans
- Improves SkillMetadataBar to show install count suffix and deduplicated path display

Fixes #9