### PR TITLE
perf: cache Highlightr instance to fix ~2s preview delay

### DIFF
--- a/Chops/Utilities/HighlightrSyntaxHighlighter.swift
+++ b/Chops/Utilities/HighlightrSyntaxHighlighter.swift
@@ -3,13 +3,14 @@ import Highlightr
 import SwiftUI
 
 struct HighlightrSyntaxHighlighter: CodeSyntaxHighlighter {
+    private static let shared: Highlightr = Highlightr()!
+
     private let highlightr: Highlightr
 
     init() {
-        let h = Highlightr()!
+        self.highlightr = Self.shared
         let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        h.setTheme(to: isDark ? "atom-one-dark" : "atom-one-light")
-        self.highlightr = h
+        highlightr.setTheme(to: isDark ? "atom-one-dark" : "atom-one-light")
     }
 
     func highlightCode(_ code: String, language: String?) -> Text {

--- a/Chops/Views/Detail/SkillPreviewView.swift
+++ b/Chops/Views/Detail/SkillPreviewView.swift
@@ -5,17 +5,16 @@ struct SkillPreviewView: View {
     let content: String
 
     var body: some View {
-        let parsed = FrontmatterParser.parse(content)
-        let rawFrontmatter = RawFrontmatterParser.parse(content)
+        let parsed = RawFrontmatterParser.parse(content)
 
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                if let rawFrontmatter {
-                    FrontmatterBlockView(frontmatter: rawFrontmatter)
+                if let frontmatter = parsed?.frontmatter {
+                    FrontmatterBlockView(frontmatter: frontmatter)
                         .padding(.bottom, 24)
                 }
 
-                Markdown(parsed.content)
+                Markdown(parsed?.content ?? content)
                     .markdownTheme(.clearly)
                     .markdownCodeSyntaxHighlighter(HighlightrSyntaxHighlighter())
                     .textSelection(.enabled)
@@ -53,7 +52,12 @@ private struct FrontmatterBlockView: View {
 }
 
 private enum RawFrontmatterParser {
-    static func parse(_ text: String) -> String? {
+    struct Result {
+        let frontmatter: String?
+        let content: String
+    }
+
+    static func parse(_ text: String) -> Result? {
         let lines = text.components(separatedBy: "\n")
 
         guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
@@ -65,7 +69,13 @@ private enum RawFrontmatterParser {
                 let frontmatterLines = Array(lines[1..<index])
                 let frontmatter = frontmatterLines.joined(separator: "\n")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
-                return frontmatter.isEmpty ? nil : frontmatter
+                let contentStart = min(index + 1, lines.count)
+                let content = Array(lines[contentStart...]).joined(separator: "\n")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return Result(
+                    frontmatter: frontmatter.isEmpty ? nil : frontmatter,
+                    content: content
+                )
             }
         }
 


### PR DESCRIPTION
## Summary
- Cache the `Highlightr` instance as a static singleton so the expensive JavaScriptCore context initialization (loading highlight.js grammars + themes) happens once per app lifetime instead of on every SwiftUI view render
- Consolidate duplicate frontmatter parsing in `SkillPreviewView` into a single pass, eliminating the redundant `FrontmatterParser.parse()` call

## Test plan
- [ ] Build and launch the app
- [ ] Click between skills rapidly with preview mode active — should be near-instant
- [ ] Toggle dark/light mode and confirm syntax highlighting theme updates
- [ ] Verify skills with no frontmatter still render correctly