### PR TITLE
feat: drag and drop skills into sidebar collections

### DIFF
--- a/Chops/Views/Sidebar/CollectionListView.swift
+++ b/Chops/Views/Sidebar/CollectionListView.swift
@@ -80,6 +80,21 @@ struct CollectionListView: View {
         }
     }
 
+    private func handleDrop(_ resolvedPaths: [String], onto collection: SkillCollection) -> Bool {
+        var added = false
+        for path in resolvedPaths {
+            let descriptor = FetchDescriptor<Skill>(
+                predicate: #Predicate { $0.resolvedPath == path }
+            )
+            guard let skill = try? modelContext.fetch(descriptor).first else { continue }
+            guard !collection.skills.contains(where: { $0.resolvedPath == path }) else { continue }
+            collection.skills.append(skill)
+            added = true
+        }
+        if added { try? modelContext.save() }
+        return added
+    }
+
     private let availableIcons = [
         "folder", "star", "bookmark", "tag", "tray",
         "archivebox", "doc.text", "gearshape", "wrench",
@@ -110,6 +125,9 @@ struct CollectionListView: View {
                 Label(collection.name, systemImage: collection.icon)
                     .badge(collection.skills.count)
                     .tag(SidebarFilter.collection(collection.name))
+                    .dropDestination(for: String.self) { resolvedPaths, _ in
+                        handleDrop(resolvedPaths, onto: collection)
+                    }
                     .contextMenu {
                         Button("Rename") {
                             errorMessage = nil

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -81,6 +81,7 @@ struct SkillListView: View {
             ForEach(filteredSkills) { skill in
                 SkillRow(skill: skill)
                     .tag(skill)
+                    .draggable(skill.resolvedPath)
                     .contextMenu {
                         Button(skill.isFavorite ? "Unfavorite" : "Favorite") {
                             skill.isFavorite.toggle()


### PR DESCRIPTION
## Summary
- Makes skill rows in the list draggable using their `resolvedPath` as the transfer payload
- Adds drop targets on sidebar collection items to accept dragged skills
- Looks up the skill by path on drop, appends to the collection, and saves — duplicates are silently ignored

## Test plan
- [ ] Drag a skill from the list onto a sidebar collection
- [ ] Verify the collection badge count increments
- [ ] Click the collection to confirm the skill appears
- [ ] Drag the same skill again — no duplicate should be added