### PR TITLE
feat: add 'Copy to Agent' feature for skills

### DIFF
--- a/Chops/Models/Skill.swift
+++ b/Chops/Models/Skill.swift
@@ -164,6 +164,58 @@ final class Skill {
             try fm.removeItem(atPath: path)
         }
     }
+
+    /// Copy this skill to another tool's skill directory
+    func copyToTool(_ targetTool: ToolSource) throws {
+        let fm = FileManager.default
+
+        // Get the source path (prefer the original filePath)
+        let sourcePath = filePath
+        guard fm.fileExists(atPath: sourcePath) else {
+            throw SkillCopyError.sourceNotFound(sourcePath)
+        }
+
+        // Get target tool's skill directory
+        guard let targetDir = targetTool.globalPaths.first else {
+            throw SkillCopyError.targetToolHasNoPath(targetTool.displayName)
+        }
+
+        // Create target directory if it doesn't exist
+        try fm.createDirectory(atPath: targetDir, withIntermediateDirectories: true)
+
+        // Determine source and destination
+        let sourceFolderPath: String
+        let destinationPath: String
+
+        if isDirectory {
+            // If source is a directory, copy the folder directly
+            sourceFolderPath = sourcePath
+            destinationPath = (targetDir as NSString).appendingPathComponent((sourcePath as NSString).lastPathComponent)
+        } else {
+            // If source is a file, copy its containing folder
+            sourceFolderPath = (sourcePath as NSString).deletingLastPathComponent
+            destinationPath = (targetDir as NSString).appendingPathComponent((sourceFolderPath as NSString).lastPathComponent)
+        }
+
+        // Don't copy if already exists at destination
+        if fm.fileExists(atPath: destinationPath) {
+            throw SkillCopyError.alreadyExists(destinationPath)
+        }
+
+        // Copy the folder
+        try fm.copyItem(atPath: sourceFolderPath, toPath: destinationPath)
+
+        // Determine the actual copied file path
+        let copiedFilePath: String
+        if isDirectory {
+            copiedFilePath = destinationPath
+        } else {
+            copiedFilePath = (destinationPath as NSString).appendingPathComponent((sourcePath as NSString).lastPathComponent)
+        }
+
+        // Update this skill's metadata to track the new installation
+        addInstallation(path: copiedFilePath, tool: targetTool)
+    }
 }
 
 enum SkillDeletionError: LocalizedError {
@@ -175,6 +227,27 @@ enum SkillDeletionError: LocalizedError {
             let home = FileManager.default.homeDirectoryForCurrentUser.path
             let displayPath = path.replacingOccurrences(of: home, with: "~")
             return "Couldn't delete \(displayPath). Check permissions and try again."
+        }
+    }
+}
+
+enum SkillCopyError: LocalizedError {
+    case sourceNotFound(String)
+    case targetToolHasNoPath(String)
+    case alreadyExists(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .sourceNotFound(let path):
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let displayPath = path.replacingOccurrences(of: home, with: "~")
+            return "Source skill not found at \(displayPath)."
+        case .targetToolHasNoPath(let toolName):
+            return "\(toolName) doesn't have a configured skills directory."
+        case .alreadyExists(let path):
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let displayPath = path.replacingOccurrences(of: home, with: "~")
+            return "This skill is already installed at \(displayPath)."
         }
     }
 }

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -5,6 +5,7 @@ struct SkillListView: View {
     private enum ActiveAlert: Identifiable {
         case confirmDelete(Skill)
         case deleteError(String)
+        case copyError(String)
 
         var id: String {
             switch self {
@@ -12,6 +13,8 @@ struct SkillListView: View {
                 return "confirm-delete-\(skill.filePath)"
             case .deleteError(let message):
                 return "delete-error-\(message)"
+            case .copyError(let message):
+                return "copy-error-\(message)"
             }
         }
     }
@@ -109,6 +112,27 @@ struct SkillListView: View {
                         }
                         if !skill.isRemote {
                             Divider()
+                            
+                            // Copy to Agent menu - show only tools that have skills
+                            let availableTools = ToolSource.allCases.filter { tool in
+                                allSkills.contains { $0.toolSources.contains(tool) } && !skill.toolSources.contains(tool)
+                            }
+                            
+                            if !availableTools.isEmpty {
+                                Menu("Copy to Agent") {
+                                    ForEach(availableTools) { tool in
+                                        Button(tool.displayName) {
+                                            do {
+                                                try skill.copyToTool(tool)
+                                                try modelContext.save()
+                                            } catch {
+                                                activeAlert = .copyError(error.localizedDescription)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            
                             Button("Show in Finder") {
                                 NSWorkspace.shared.selectFile(skill.filePath, inFileViewerRootedAtPath: "")
                             }
@@ -135,6 +159,12 @@ struct SkillListView: View {
             case .deleteError(let message):
                 return Alert(
                     title: Text("Delete Failed"),
+                    message: Text(message),
+                    dismissButton: .default(Text("OK"))
+                )
+            case .copyError(let message):
+                return Alert(
+                    title: Text("Copy Failed"),
                     message: Text(message),
                     dismissButton: .default(Text("OK"))
                 )


### PR DESCRIPTION
## What
Adds the ability to copy a skill to any other agent/tool that has skills.

## How
- User right-clicks a skill in the sidebar
- Selects 'Copy to Agent' from the context menu
- Chooses from available agents (those that have skills, excluding the current one)
- Full skill folder is copied to the target agent's skill directory
- Skill metadata updated to track installation across multiple agents

## Details
- **copyToTool()** method in Skill model handles folder copying
- **SkillCopyError** enum for detailed error reporting
- Only shows agents with existing skills in the context menu (matching sidebar Tools section)
- Prevents copying to already-installed agents

Fixes: Copy skill functionality