### PR TITLE
feat: support scanning and displaying agents alongside skills

### DIFF
--- a/Chops/App/AppState.swift
+++ b/Chops/App/AppState.swift
@@ -7,11 +7,13 @@ final class AppState {
     var searchText: String = ""
     var showingNewSkillSheet: Bool = false
     var showingRegistrySheet: Bool = false
-    var sidebarFilter: SidebarFilter = .all
+    var newItemKind: ItemKind = .skill
+    var sidebarFilter: SidebarFilter = .allSkills
 }
 
 enum SidebarFilter: Hashable {
-    case all
+    case allSkills
+    case allAgents
     case favorites
     case tool(ToolSource)
     case collection(String)

--- a/Chops/App/ContentView.swift
+++ b/Chops/App/ContentView.swift
@@ -20,14 +20,23 @@ struct ContentView: View {
             if let skill = appState.selectedSkill {
                 SkillDetailView(skill: skill)
             } else {
-                ContentUnavailableView(
-                    "Select a Skill",
-                    systemImage: "doc.text",
-                    description: Text("Choose a skill from the sidebar to view and edit it.")
-                )
+                switch appState.sidebarFilter {
+                case .allAgents:
+                    ContentUnavailableView(
+                        "Select an Agent",
+                        systemImage: "person.crop.rectangle",
+                        description: Text("Choose an agent from the sidebar to view and edit it.")
+                    )
+                default:
+                    ContentUnavailableView(
+                        "Select a Skill",
+                        systemImage: "doc.text",
+                        description: Text("Choose a skill from the sidebar to view and edit it.")
+                    )
+                }
             }
         }
-        .searchable(text: $appState.searchText, prompt: "Search skills...")
+        .searchable(text: $appState.searchText, prompt: appState.sidebarFilter == .allAgents ? "Search agents..." : "Search skills...")
         .onAppear {
             startScanning()
         }
@@ -41,10 +50,18 @@ struct ContentView: View {
             ToolbarItem(placement: .primaryAction) {
                 Menu {
                     Button {
+                        appState.newItemKind = .skill
                         appState.showingNewSkillSheet = true
                     } label: {
-                        Label("New Skill", systemImage: "plus")
+                        Label("New Skill", systemImage: "doc.text")
                     }
+                    Button {
+                        appState.newItemKind = .agent
+                        appState.showingNewSkillSheet = true
+                    } label: {
+                        Label("New Agent", systemImage: "person.crop.rectangle")
+                    }
+                    Divider()
                     Button {
                         appState.showingRegistrySheet = true
                     } label: {
@@ -72,6 +89,7 @@ struct ContentView: View {
         var allPaths: [String] = []
         for tool in ToolSource.allCases {
             allPaths.append(contentsOf: tool.globalPaths)
+            allPaths.append(contentsOf: tool.globalAgentPaths)
         }
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser.path

--- a/Chops/Models/Skill.swift
+++ b/Chops/Models/Skill.swift
@@ -1,6 +1,11 @@
 import SwiftData
 import Foundation
 
+enum ItemKind: String, Codable, CaseIterable {
+    case skill
+    case agent
+}
+
 @Model
 final class Skill {
     @Attribute(.unique) var resolvedPath: String
@@ -29,7 +34,19 @@ final class Skill {
     /// All file paths where this skill is installed (JSON-encoded array)
     var installedPathsData: Data?
 
+    /// Discriminator: "skill" or "agent"
+    var kind: String = ItemKind.skill.rawValue
+
     // MARK: - Computed
+
+    var itemKind: ItemKind {
+        get { ItemKind(rawValue: kind) ?? .skill }
+        set { kind = newValue.rawValue }
+    }
+
+    var displayTypeName: String {
+        itemKind == .agent ? "Agent" : "Skill"
+    }
 
     var toolSources: [ToolSource] {
         get {
@@ -102,7 +119,8 @@ final class Skill {
         fileModifiedDate: Date = .now,
         fileSize: Int = 0,
         isGlobal: Bool = true,
-        resolvedPath: String = ""
+        resolvedPath: String = "",
+        kind: ItemKind = .skill
     ) {
         self.resolvedPath = resolvedPath.isEmpty ? filePath : resolvedPath
         self.filePath = filePath
@@ -120,6 +138,7 @@ final class Skill {
         self.fileModifiedDate = fileModifiedDate
         self.fileSize = fileSize
         self.isGlobal = isGlobal
+        self.kind = kind.rawValue
     }
 
     // MARK: - Merge

--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -30,7 +30,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .openclaw: "OpenClaw"
         case .opencode: "OpenCode"
         case .pi: "Pi"
-        case .agents: "Global Agents"
+        case .agents: "Global"
         case .antigravity: "Antigravity"
         case .claudeDesktop: "Claude Desktop"
         case .custom: "Custom"
@@ -89,6 +89,16 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .antigravity: .red
         case .claudeDesktop: .orange
         case .custom: .gray
+        }
+    }
+
+    var globalAgentPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        switch self {
+        case .claude: return ["\(home)/.claude/agents"]
+        case .cursor: return ["\(home)/.cursor/agents"]
+        case .codex: return ["\(home)/.codex/agents"]
+        default: return []
         }
     }
 

--- a/Chops/Services/SkillRegistry.swift
+++ b/Chops/Services/SkillRegistry.swift
@@ -208,9 +208,9 @@ final class SkillRegistry {
             case .searchFailed: "Search request failed"
             case .treeFetchFailed: "Could not fetch repository contents"
             case .rateLimited: "GitHub API rate limit reached — try again in a few minutes"
-            case .skillNotFound: "Skill file not found in repository"
-            case .invalidSkillName: "Invalid skill name"
-            case .skillAlreadyExists: "Skill is already installed for all selected agents"
+            case .skillNotFound: "File not found in repository"
+            case .invalidSkillName: "Invalid name"
+            case .skillAlreadyExists: "Already installed for all selected targets"
             }
         }
     }

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -15,6 +15,7 @@ struct ScannedSkillData: Sendable {
     let frontmatter: [String: String]
     let modDate: Date
     let fileSize: Int
+    let kind: ItemKind
 }
 
 @Observable
@@ -47,15 +48,19 @@ final class SkillScanner {
     }
 
     /// Project-level paths to probe inside each project directory
-    private static let projectProbes: [(subpath: String, tool: ToolSource)] = [
-        (".claude/skills", .claude),
-        (".cursor/skills", .cursor),
-        (".cursor/rules", .cursor),
-        (".codex/skills", .codex),
-        (".windsurf/rules", .windsurf),
-        (".github", .copilot),
-        (".config/amp/skills", .amp),
-        (".opencode/skills", .opencode),
+    private static let projectProbes: [(subpath: String, tool: ToolSource, kind: ItemKind)] = [
+        (".claude/skills", .claude, .skill),
+        (".claude/agents", .claude, .agent),
+        (".cursor/skills", .cursor, .skill),
+        (".cursor/rules", .cursor, .skill),
+        (".cursor/agents", .cursor, .agent),
+        (".codex/skills", .codex, .skill),
+        (".codex/agents", .codex, .agent),
+        (".windsurf/rules", .windsurf, .skill),
+        (".github", .copilot, .skill),
+        (".github/agents", .copilot, .agent),
+        (".config/amp/skills", .amp, .skill),
+        (".opencode/skills", .opencode, .skill),
     ]
 
     func scanAll() {
@@ -92,7 +97,11 @@ final class SkillScanner {
             }
             for path in tool.globalPaths {
                 let url = URL(fileURLWithPath: path)
-                collectFromDirectory(url, toolSource: tool, isGlobal: true, into: &results)
+                collectFromDirectory(url, toolSource: tool, isGlobal: true, kind: .skill, into: &results)
+            }
+            for path in tool.globalAgentPaths {
+                let url = URL(fileURLWithPath: path)
+                collectFromDirectory(url, toolSource: tool, isGlobal: true, kind: .agent, into: &results)
             }
         }
 
@@ -132,21 +141,21 @@ final class SkillScanner {
                 let probePath = project.appendingPathComponent(probe.subpath)
                 guard fm.fileExists(atPath: probePath.path) else { continue }
 
-                if probe.tool == .copilot {
+                if probe.tool == .copilot && probe.kind == .skill {
                     let file = probePath.appendingPathComponent("copilot-instructions.md")
                     if fm.fileExists(atPath: file.path) {
-                        if let data = collectSkillData(at: file, toolSource: .copilot, isDirectory: false, isGlobal: false) {
+                        if let data = collectSkillData(at: file, toolSource: .copilot, isDirectory: false, isGlobal: false, kind: probe.kind) {
                             results.append(data)
                         }
                     }
                 } else {
-                    collectFromDirectory(probePath, toolSource: probe.tool, isGlobal: false, into: &results)
+                    collectFromDirectory(probePath, toolSource: probe.tool, isGlobal: false, kind: probe.kind, into: &results)
                 }
             }
         }
     }
 
-    private static func collectFromDirectory(_ directory: URL, toolSource: ToolSource, isGlobal: Bool, into results: inout [ScannedSkillData]) {
+    private static func collectFromDirectory(_ directory: URL, toolSource: ToolSource, isGlobal: Bool, kind: ItemKind = .skill, into results: inout [ScannedSkillData]) {
         let fm = FileManager.default
 
         var isDir: ObjCBool = false
@@ -170,21 +179,53 @@ final class SkillScanner {
                 let agentsFile = item.appendingPathComponent("AGENTS.md")
 
                 if fm.fileExists(atPath: skillFile.path) {
-                    if let data = collectSkillData(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
+                    if let data = collectSkillData(at: skillFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal, kind: kind) {
                         results.append(data)
                     }
                 } else if fm.fileExists(atPath: agentsFile.path) {
-                    if let data = collectSkillData(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal) {
+                    if let data = collectSkillData(at: agentsFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal, kind: kind) {
+                        results.append(data)
+                    }
+                } else if kind == .agent, let agentFile = preferredAgentFile(in: item) {
+                    if let data = collectSkillData(at: agentFile, toolSource: toolSource, isDirectory: true, isGlobal: isGlobal, kind: kind) {
                         results.append(data)
                     }
                 }
-            } else if item.pathExtension == "md" || item.pathExtension == "mdc" {
+            } else if item.pathExtension == "md" || item.pathExtension == "mdc" || item.pathExtension == "toml" {
                 guard !shouldIgnoreLooseMarkdownFile(named: item.lastPathComponent) else { continue }
-                if let data = collectSkillData(at: item, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal) {
+                if let data = collectSkillData(at: item, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal, kind: kind) {
                     results.append(data)
                 }
             }
         }
+    }
+
+    private static func preferredAgentFile(in directory: URL) -> URL? {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+
+        let candidates = contents.filter { item in
+            var isDir: ObjCBool = false
+            fm.fileExists(atPath: item.path, isDirectory: &isDir)
+            guard !isDir.boolValue else { return false }
+            guard ["md", "mdc", "toml"].contains(item.pathExtension) else { return false }
+            return !shouldIgnoreLooseMarkdownFile(named: item.lastPathComponent)
+        }
+
+        let directoryName = directory.lastPathComponent.lowercased()
+        if let matchingFile = candidates.first(where: { $0.deletingPathExtension().lastPathComponent.lowercased() == directoryName }) {
+            return matchingFile
+        }
+
+        if candidates.count == 1 {
+            return candidates[0]
+        }
+
+        return nil
     }
 
     /// For Claude Desktop plugin paths, produce a canonical identity that strips volatile
@@ -231,7 +272,7 @@ final class SkillScanner {
     }
 
     /// Read and parse a single skill file. Pure I/O, no SwiftData.
-    private static func collectSkillData(at fileURL: URL, toolSource: ToolSource, isDirectory: Bool, isGlobal: Bool) -> ScannedSkillData? {
+    private static func collectSkillData(at fileURL: URL, toolSource: ToolSource, isDirectory: Bool, isGlobal: Bool, kind: ItemKind = .skill) -> ScannedSkillData? {
         let fm = FileManager.default
         let resolved = canonicalResolvedPath(for: fileURL, toolSource: toolSource)
 
@@ -266,7 +307,8 @@ final class SkillScanner {
             content: parsed.content,
             frontmatter: parsed.frontmatter,
             modDate: modDate,
-            fileSize: fileSize
+            fileSize: fileSize,
+            kind: kind
         )
     }
 
@@ -385,6 +427,7 @@ final class SkillScanner {
                 existing.isGlobal = preferredData.isGlobal
                 existing.installedPaths = installedPaths
                 existing.toolSources = toolSources
+                existing.itemKind = preferredData.kind
             } else {
                 let skill = Skill(
                     filePath: primary.fileURL.path,
@@ -397,7 +440,8 @@ final class SkillScanner {
                     fileModifiedDate: primary.modDate,
                     fileSize: primary.fileSize,
                     isGlobal: primary.isGlobal,
-                    resolvedPath: primary.resolvedPath
+                    resolvedPath: primary.resolvedPath,
+                    kind: primary.kind
                 )
                 skill.installedPaths = installedPaths
                 skill.toolSources = toolSources

--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -85,14 +85,14 @@ struct SkillDetailView: View {
                 } label: {
                     Image(systemName: "trash")
                 }
-                .help("Delete Skill")
+                .help("Delete \(skill.displayTypeName)")
             }
         }
         .alert(item: $activeAlert) { alert in
             switch alert {
             case .confirmDelete:
                 return Alert(
-                    title: Text("Delete Skill?"),
+                    title: Text("Delete \(skill.displayTypeName)?"),
                     message: Text("This will permanently delete \"\(skill.name)\" from disk."),
                     primaryButton: .destructive(Text("Delete")) {
                         deleteSkill()

--- a/Chops/Views/Settings/DiagnosticExporter.swift
+++ b/Chops/Views/Settings/DiagnosticExporter.swift
@@ -24,8 +24,12 @@ enum DiagnosticExporter {
         // Skill counts
         let descriptor = FetchDescriptor<Skill>()
         let skills = (try? modelContext.fetch(descriptor)) ?? []
-        lines.append("## Skills")
+        let skillsOnly = skills.filter { $0.itemKind == .skill }
+        let agentsOnly = skills.filter { $0.itemKind == .agent }
+        lines.append("## Items")
         lines.append("- Total: \(skills.count)")
+        lines.append("- Skills: \(skillsOnly.count)")
+        lines.append("- Agents: \(agentsOnly.count)")
         for tool in ToolSource.allCases {
             let count = skills.filter { $0.toolSources.contains(tool) }.count
             if count > 0 {

--- a/Chops/Views/Settings/RemoteServersSettingsView.swift
+++ b/Chops/Views/Settings/RemoteServersSettingsView.swift
@@ -222,7 +222,7 @@ private struct AddServerSheet: View {
                 TextField("Host", text: $host, prompt: Text("192.168.1.100"))
                 TextField("Port", text: $port, prompt: Text("22"))
                 TextField("Username", text: $username, prompt: Text("root"))
-                TextField("Skills Base Path", text: $basePath, prompt: Text("e.g. ~/.openclaw, ~/skills"))
+                TextField("Base Path", text: $basePath, prompt: Text("e.g. ~/.openclaw, ~/skills"))
                 TextField("SSH Key Path", text: $sshKeyPath, prompt: Text("Optional — e.g. ~/.ssh/id_ed25519"))
             }
             .formStyle(.grouped)
@@ -337,7 +337,7 @@ private struct EditServerSheet: View {
                 TextField("Host", text: $host, prompt: Text("192.168.1.100"))
                 TextField("Port", text: $port, prompt: Text("22"))
                 TextField("Username", text: $username, prompt: Text("root"))
-                TextField("Skills Base Path", text: $basePath, prompt: Text("e.g. ~/.openclaw, ~/skills"))
+                TextField("Base Path", text: $basePath, prompt: Text("e.g. ~/.openclaw, ~/skills"))
                 TextField("SSH Key Path", text: $sshKeyPath, prompt: Text("Optional — e.g. ~/.ssh/id_ed25519"))
             }
             .formStyle(.grouped)

--- a/Chops/Views/Settings/SettingsView.swift
+++ b/Chops/Views/Settings/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView: View {
 
     private var generalSettings: some View {
         Form {
-            Picker("Default tool for new skills", selection: $defaultTool) {
+            Picker("Default tool", selection: $defaultTool) {
                 ForEach(ToolSource.allCases) { tool in
                     Text(tool.displayName).tag(tool)
                 }
@@ -55,7 +55,7 @@ struct SettingsView: View {
             Text("Custom Scan Directories")
                 .font(.headline)
 
-            Text("Add a parent directory (e.g. ~/Development) and Chops will scan each project inside it for tool-specific skills.")
+            Text("Add a parent directory (e.g. ~/Development) and Chops will scan each project inside it for tool-specific skills and agents.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -125,7 +125,7 @@ struct SettingsView: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
-            Text("Your AI agent skills, finally organized.")
+            Text("Your AI skills and agents, finally organized.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 

--- a/Chops/Views/Shared/NewSkillSheet.swift
+++ b/Chops/Views/Shared/NewSkillSheet.swift
@@ -9,16 +9,24 @@ struct NewSkillSheet: View {
     @State private var selectedTool: ToolSource = .claude
     @State private var errorMessage: String?
 
-    private let creatableTools: [ToolSource] = [.claude, .agents, .cursor, .codex, .amp, .opencode, .pi, .antigravity]
+    private let skillCreatableTools: [ToolSource] = [.claude, .agents, .cursor, .codex, .amp, .opencode, .pi, .antigravity]
+    private let agentCreatableTools: [ToolSource] = [.claude, .cursor, .codex]
+
+    private var itemKind: ItemKind { appState.newItemKind }
+    private var isAgent: Bool { itemKind == .agent }
+
+    private var creatableTools: [ToolSource] {
+        isAgent ? agentCreatableTools : skillCreatableTools
+    }
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("New Skill")
+            Text(isAgent ? "New Agent" : "New Skill")
                 .font(.title2)
                 .fontWeight(.bold)
 
             Form {
-                TextField("Skill name", text: $skillName)
+                TextField(isAgent ? "Agent name" : "Skill name", text: $skillName)
                     .textFieldStyle(.roundedBorder)
 
                 Picker("Tool", selection: $selectedTool) {
@@ -45,7 +53,7 @@ struct NewSkillSheet: View {
                 Spacer()
 
                 Button("Create") {
-                    createSkill()
+                    createItem()
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(skillName.isEmpty)
@@ -53,9 +61,15 @@ struct NewSkillSheet: View {
         }
         .padding(24)
         .frame(width: 400)
+        .onAppear {
+            // Ensure selectedTool is valid for the current item kind
+            if !creatableTools.contains(selectedTool) {
+                selectedTool = creatableTools.first ?? .claude
+            }
+        }
     }
 
-    private func createSkill() {
+    private func createItem() {
         let fm = FileManager.default
         let configHome: String = {
             if let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"], !xdg.isEmpty {
@@ -69,78 +83,73 @@ struct NewSkillSheet: View {
             .filter { $0.isLetter || $0.isNumber || $0 == "-" }
 
         guard !sanitizedName.isEmpty else {
-            errorMessage = "Invalid skill name"
+            errorMessage = "Invalid name"
             return
         }
 
         let basePath: String
         let fileName: String
-        let isDirectory: Bool
 
-        switch selectedTool {
-        case .claude:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.claude/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .agents:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.agents/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .cursor:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.cursor/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .codex:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.codex/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .amp:
-            basePath = "\(configHome)/amp/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .opencode:
-            basePath = "\(configHome)/opencode/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .pi:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.pi/agent/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        case .antigravity:
-            basePath = "\(fm.homeDirectoryForCurrentUser.path)/.gemini/antigravity/skills/\(sanitizedName)"
-            fileName = "SKILL.md"
-            isDirectory = true
-        default:
-            let firstPath = selectedTool.globalPaths.first ?? "\(fm.homeDirectoryForCurrentUser.path)/.claude/skills/\(sanitizedName)"
-            basePath = firstPath
-            fileName = "SKILL.md"
-            isDirectory = true
+        if isAgent {
+            // Agents go into the tool's agents/ directory
+            guard let agentDir = selectedTool.globalAgentPaths.first else {
+                errorMessage = "This tool doesn't support agents"
+                return
+            }
+            basePath = "\(agentDir)/\(sanitizedName)"
+            fileName = "\(sanitizedName).md"
+        } else {
+            // Skills use existing path logic
+            switch selectedTool {
+            case .claude:
+                basePath = "\(fm.homeDirectoryForCurrentUser.path)/.claude/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .agents:
+                basePath = "\(fm.homeDirectoryForCurrentUser.path)/.agents/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .cursor:
+                basePath = "\(fm.homeDirectoryForCurrentUser.path)/.cursor/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .codex:
+                basePath = "\(fm.homeDirectoryForCurrentUser.path)/.codex/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .amp:
+                basePath = "\(configHome)/amp/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .opencode:
+                basePath = "\(configHome)/opencode/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .pi:
+                basePath = "\(fm.homeDirectoryForCurrentUser.path)/.pi/agent/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            case .antigravity:
+                basePath = "\(fm.homeDirectoryForCurrentUser.path)/.gemini/antigravity/skills/\(sanitizedName)"
+                fileName = "SKILL.md"
+            default:
+                let firstPath = selectedTool.globalPaths.first ?? "\(fm.homeDirectoryForCurrentUser.path)/.claude/skills/\(sanitizedName)"
+                basePath = firstPath
+                fileName = "SKILL.md"
+            }
         }
 
         do {
-            if isDirectory {
-                try fm.createDirectory(atPath: basePath, withIntermediateDirectories: true)
-            } else {
-                try fm.createDirectory(atPath: basePath, withIntermediateDirectories: true)
-            }
+            try fm.createDirectory(atPath: basePath, withIntermediateDirectories: true)
 
-            let filePath = isDirectory ? "\(basePath)/\(fileName)" : "\(basePath)/\(fileName)"
+            let filePath = "\(basePath)/\(fileName)"
 
-            // Don't overwrite existing files
             guard !fm.fileExists(atPath: filePath) else {
-                errorMessage = "A skill with this name already exists"
+                errorMessage = isAgent ? "An agent with this name already exists" : "A skill with this name already exists"
                 return
             }
 
             let boilerplate = generateBoilerplate(name: skillName, skillID: sanitizedName, tool: selectedTool)
             try boilerplate.write(toFile: filePath, atomically: true, encoding: .utf8)
 
-            // Insert into SwiftData
             let parsed = FrontmatterParser.parse(boilerplate)
             let skill = Skill(
                 filePath: filePath,
                 toolSource: selectedTool,
-                isDirectory: isDirectory,
+                isDirectory: true,
                 name: skillName,
                 skillDescription: parsed.description,
                 content: parsed.content,
@@ -148,7 +157,8 @@ struct NewSkillSheet: View {
                 fileModifiedDate: .now,
                 fileSize: boilerplate.count,
                 isGlobal: true,
-                resolvedPath: filePath
+                resolvedPath: filePath,
+                kind: itemKind
             )
             modelContext.insert(skill)
             try modelContext.save()
@@ -161,6 +171,21 @@ struct NewSkillSheet: View {
     }
 
     private func generateBoilerplate(name: String, skillID: String, tool: ToolSource) -> String {
+        if isAgent {
+            return """
+            ---
+            name: \(skillID)
+            description: \(name)
+            ---
+
+            # \(name)
+
+            ## Instructions
+
+            Add your agent instructions here.
+            """
+        }
+
         switch tool {
         case .claude, .cursor:
             return """

--- a/Chops/Views/Sidebar/SidebarView.swift
+++ b/Chops/Views/Sidebar/SidebarView.swift
@@ -26,9 +26,13 @@ struct SidebarView: View {
 
         List(selection: $appState.sidebarFilter) {
             Section("Library") {
-                Label("All Skills", systemImage: "tray.full")
-                    .badge(allSkills.count)
-                    .tag(SidebarFilter.all)
+                Label("All Skills", systemImage: "doc.text")
+                    .badge(allSkills.filter { $0.itemKind == .skill }.count)
+                    .tag(SidebarFilter.allSkills)
+
+                Label("All Agents", systemImage: "person.crop.rectangle")
+                    .badge(allSkills.filter { $0.itemKind == .agent }.count)
+                    .tag(SidebarFilter.allAgents)
 
                 Label("Favorites", systemImage: "star")
                     .badge(allSkills.filter(\.isFavorite).count)

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -26,8 +26,10 @@ struct SkillListView: View {
         var result = allSkills
 
         switch appState.sidebarFilter {
-        case .all:
-            break
+        case .allSkills:
+            result = result.filter { $0.itemKind == .skill }
+        case .allAgents:
+            result = result.filter { $0.itemKind == .agent }
         case .favorites:
             result = result.filter { $0.isFavorite }
         case .tool(let tool):
@@ -53,12 +55,21 @@ struct SkillListView: View {
 
     private var title: String {
         switch appState.sidebarFilter {
-        case .all: "All Skills"
+        case .allSkills: "All Skills"
+        case .allAgents: "All Agents"
         case .favorites: "Favorites"
         case .tool(let tool): tool.displayName
         case .collection(let name): name
         case .server(let id):
-            allSkills.first(where: { $0.remoteServer?.id == id })?.remoteServer?.label ?? "Remote Skills"
+            allSkills.first(where: { $0.remoteServer?.id == id })?.remoteServer?.label ?? "Remote"
+        }
+    }
+
+    /// Whether the current filter shows mixed item types (skills and agents together)
+    private var showsTypeBadge: Bool {
+        switch appState.sidebarFilter {
+        case .allSkills, .allAgents: false
+        default: true
         }
     }
 
@@ -80,7 +91,7 @@ struct SkillListView: View {
 
         List(selection: $appState.selectedSkill) {
             ForEach(filteredSkills) { skill in
-                SkillRow(skill: skill)
+                SkillRow(skill: skill, showTypeBadge: showsTypeBadge)
                     .tag(skill)
                     .draggable(skill.resolvedPath)
                     .contextMenu {
@@ -125,7 +136,7 @@ struct SkillListView: View {
             switch alert {
             case .confirmDelete(let skill):
                 return Alert(
-                    title: Text("Delete Skill?"),
+                    title: Text("Delete \(skill.displayTypeName)?"),
                     message: Text("This will permanently delete \"\(skill.name)\" from disk."),
                     primaryButton: .destructive(Text("Delete")) {
                         deleteSkill(skill)
@@ -143,9 +154,11 @@ struct SkillListView: View {
         .overlay {
             if filteredSkills.isEmpty {
                 ContentUnavailableView(
-                    "No Skills",
-                    systemImage: "doc.text",
-                    description: Text("No skills match the current filter.")
+                    appState.sidebarFilter == .allAgents ? "No Agents" : "No Skills",
+                    systemImage: appState.sidebarFilter == .allAgents ? "person.crop.rectangle" : "doc.text",
+                    description: Text(appState.sidebarFilter == .allAgents
+                        ? "No agents match the current filter."
+                        : "No skills match the current filter.")
                 )
             }
         }
@@ -154,9 +167,16 @@ struct SkillListView: View {
 
 struct SkillRow: View {
     let skill: Skill
+    var showTypeBadge: Bool = false
 
     var body: some View {
         HStack(spacing: 6) {
+            if showTypeBadge {
+                Image(systemName: skill.itemKind == .agent ? "person.crop.rectangle" : "doc.text")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
             Text(skill.name)
                 .lineLimit(1)
 

--- a/Chops/Views/Sidebar/ToolFilterView.swift
+++ b/Chops/Views/Sidebar/ToolFilterView.swift
@@ -19,7 +19,7 @@ struct ToolFilterView: View {
         ForEach(activeSources) { tool in
             Button {
                 if appState.sidebarFilter == .tool(tool) {
-                    appState.sidebarFilter = .all
+                    appState.sidebarFilter = .allSkills
                 } else {
                     appState.sidebarFilter = .tool(tool)
                 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">Chops</h1>
 
-<p align="center">Your AI agent skills, finally organized.</p>
+<p align="center">Your AI skills and agents, finally organized.</p>
 
 <p align="center">
   <a href="https://github.com/Shpigford/chops/releases/latest/download/Chops.dmg">Download</a> &middot;
@@ -16,17 +16,18 @@
   <img src="site/public/screenshot.png" width="720" alt="Chops screenshot" />
 </p>
 
-One macOS app to discover, organize, and edit coding agent skills across Claude Code, Cursor, Codex, Windsurf, and Amp. Stop digging through dotfiles.
+One macOS app to discover, organize, and edit coding agent skills and agents across Claude Code, Cursor, Codex, Windsurf, and Amp. Stop digging through dotfiles.
 
 ## Features
 
 - **Multi-tool support** — Claude Code, Cursor, Codex, Windsurf, Copilot, Aider, Amp
+- **Skills + Agents** — Discovers both skills and agents from each tool's directories
 - **Built-in editor** — Monospaced editor with Cmd+S save, frontmatter parsing
-- **Collections** — Organize skills without modifying source files
+- **Collections** — Organize skills and agents without modifying source files
 - **Real-time file watching** — FSEvents-based, instant updates on disk changes
 - **Full-text search** — Search across name, description, and content
-- **Create new skills** — Generates correct boilerplate per tool
-- **Remote skill servers** — Connect to servers like [OpenClaw](https://openclaw.ai) to discover, browse, and install skills
+- **Create new skills & agents** — Generates correct boilerplate per tool
+- **Remote servers** — Connect to servers like [OpenClaw](https://openclaw.ai) to discover, browse, and install skills
 
 ## Prerequisites
 
@@ -66,7 +67,7 @@ Chops/
 │   ├── AppState.swift         # @Observable singleton — filters, selection, search
 │   └── ContentView.swift      # Three-column NavigationSplitView, kicks off scanning
 ├── Models/
-│   ├── Skill.swift            # @Model — a discovered skill file
+│   ├── Skill.swift            # @Model — a discovered skill or agent file
 │   ├── Collection.swift       # @Model — user-created skill groupings
 │   └── ToolSource.swift       # Enum of supported tools, their paths and icons
 ├── Services/
@@ -78,7 +79,7 @@ Chops/
 │   ├── FrontmatterParser.swift  # Extracts YAML frontmatter from .md files
 │   └── MDCParser.swift          # Parses Cursor .mdc files
 ├── Views/
-│   ├── Sidebar/               # Tool filters, collection list
+│   ├── Sidebar/               # Tool filters, skills/agents lists, collections
 │   ├── Detail/                # Skill editor, metadata display
 │   ├── Settings/              # Preferences & update UI
 │   └── Shared/                # Reusable components (ToolBadge, NewSkillSheet)
@@ -122,18 +123,18 @@ Three-column `NavigationSplitView`:
 
 ## Supported Tools
 
-Chops scans these directories for skills:
+Chops scans these directories for skills and agents:
 
-| Tool | Global Paths |
-|------|-------------|
-| Claude Code | `~/.claude/skills/` |
-| Cursor | `~/.cursor/skills/`, `~/.cursor/rules` |
-| Windsurf | `~/.codeium/windsurf/memories/`, `~/.windsurf/rules` |
-| Codex | `~/.codex` |
-| Amp | `~/.config/amp` |
-| Global Agents | `~/.agents/skills/` |
+| Tool | Skills | Agents |
+|------|--------|--------|
+| Claude Code | `~/.claude/skills/` | `~/.claude/agents/` |
+| Cursor | `~/.cursor/skills/`, `~/.cursor/rules` | `~/.cursor/agents/` |
+| Windsurf | `~/.codeium/windsurf/memories/`, `~/.windsurf/rules` | — |
+| Codex | `~/.codex/skills/` | `~/.codex/agents/` |
+| Amp | `~/.config/amp/skills/` | — |
+| Global | `~/.agents/skills/` | — |
 
-Copilot and Aider are also supported but only detect project-level skills (no global paths). Custom paths can be added for any tool.
+Copilot and Aider are also supported but only detect project-level skills and agents (no global paths). Custom scan paths can be added for any tool.
 
 Tool definitions live in `Chops/Models/ToolSource.swift` — each enum case knows its display name, icon, color, and filesystem paths.
 


### PR DESCRIPTION
## Summary

- Adds agent discovery for Claude Code (`~/.claude/agents/`), Cursor (`~/.cursor/agents/`), and Codex (`~/.codex/agents/`) — both global and project-level
- Sidebar Library section now has "All Skills", "All Agents", and "Favorites" entries — no toggle, both types always accessible
- Tool filters, collections, and favorites show both types mixed with a small icon on each row to distinguish skills from agents
- "+" toolbar menu offers both "New Skill" and "New Agent" with tool-appropriate directory and boilerplate
- Updated copy throughout settings, detail views, diagnostics, and README to reflect both content types

## Test plan

- [ ] Verify "All Skills" and "All Agents" appear in sidebar Library section
- [ ] Create a test agent at `~/.claude/agents/test-agent/test-agent.md` and confirm it appears under "All Agents" and "Claude Code"
- [ ] Confirm agents do NOT appear under "All Skills"
- [ ] Click a tool filter — verify both types show with type icons on each row
- [ ] Create an agent via "New Agent" in the "+" menu — verify correct directory and boilerplate
- [ ] Verify favorites, collections, and search work with agents
- [ ] Delete an agent and verify cleanup