### PR TITLE
Add Simplified Chinese (zh-Hans) localization

### DIFF
--- a/Chops/App/ChopsApp.swift
+++ b/Chops/App/ChopsApp.swift
@@ -34,7 +34,7 @@ struct ChopsApp: App {
         .modelContainer(sharedModelContainer)
         .commands {
             CommandGroup(replacing: .saveItem) {
-                Button("Save") {
+                Button("menu.save".localized) {
                     NotificationCenter.default.post(name: .saveCurrentSkill, object: nil)
                 }
                 .keyboardShortcut("s", modifiers: .command)
@@ -44,7 +44,7 @@ struct ChopsApp: App {
                 CheckForUpdatesView(updater: updaterController.updater)
             }
             CommandGroup(after: .help) {
-                Button("Export Diagnostic Log…") {
+                Button("menu.exportDiagnostic".localized) {
                     let context = sharedModelContainer.mainContext
                     DiagnosticExporter.export(modelContext: context)
                 }
@@ -71,7 +71,7 @@ struct CheckForUpdatesView: View {
     }
 
     var body: some View {
-        Button("Check for Updates…") {
+        Button("menu.checkForUpdates".localized) {
             updater.checkForUpdates()
         }
         .disabled(!checkForUpdatesViewModel.canCheckForUpdates)

--- a/Chops/App/ContentView.swift
+++ b/Chops/App/ContentView.swift
@@ -23,20 +23,20 @@ struct ContentView: View {
                 switch appState.sidebarFilter {
                 case .allAgents:
                     ContentUnavailableView(
-                        "Select an Agent",
+                        "content.selectAgent".localized,
                         systemImage: "person.crop.rectangle",
-                        description: Text("Choose an agent from the sidebar to view and edit it.")
+                        description: Text("content.selectAgentDescription".localized)
                     )
                 default:
                     ContentUnavailableView(
-                        "Select a Skill",
+                        "content.selectSkill".localized,
                         systemImage: "doc.text",
-                        description: Text("Choose a skill from the sidebar to view and edit it.")
+                        description: Text("content.selectSkillDescription".localized)
                     )
                 }
             }
         }
-        .searchable(text: $appState.searchText, prompt: appState.sidebarFilter == .allAgents ? "Search agents..." : "Search skills...")
+        .searchable(text: $appState.searchText, prompt: appState.sidebarFilter == .allAgents ? "content.searchAgents".localized : "content.searchSkills".localized)
         .onAppear {
             startScanning()
         }
@@ -53,22 +53,22 @@ struct ContentView: View {
                         appState.newItemKind = .skill
                         appState.showingNewSkillSheet = true
                     } label: {
-                        Label("New Skill", systemImage: "doc.text")
+                        Label("content.newSkill".localized, systemImage: "doc.text")
                     }
                     Button {
                         appState.newItemKind = .agent
                         appState.showingNewSkillSheet = true
                     } label: {
-                        Label("New Agent", systemImage: "person.crop.rectangle")
+                        Label("content.newAgent".localized, systemImage: "person.crop.rectangle")
                     }
                     Divider()
                     Button {
                         appState.showingRegistrySheet = true
                     } label: {
-                        Label("Browse Registry", systemImage: "globe")
+                        Label("content.browseRegistry".localized, systemImage: "globe")
                     }
                 } label: {
-                    Label("Add", systemImage: "plus")
+                    Label("content.add".localized, systemImage: "plus")
                 }
                 .menuIndicator(.hidden)
             }

--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -20,20 +20,20 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .claude: "Claude Code"
-        case .cursor: "Cursor"
-        case .windsurf: "Windsurf"
-        case .codex: "Codex"
-        case .copilot: "Copilot"
-        case .aider: "Aider"
-        case .amp: "Amp"
-        case .openclaw: "OpenClaw"
-        case .opencode: "OpenCode"
-        case .pi: "Pi"
-        case .agents: "Global"
-        case .antigravity: "Antigravity"
-        case .claudeDesktop: "Claude Desktop"
-        case .custom: "Custom"
+        case .claude: "tool.claude".localized
+        case .cursor: "tool.cursor".localized
+        case .windsurf: "tool.windsurf".localized
+        case .codex: "tool.codex".localized
+        case .copilot: "tool.copilot".localized
+        case .aider: "tool.aider".localized
+        case .amp: "tool.amp".localized
+        case .openclaw: "tool.openclaw".localized
+        case .opencode: "tool.opencode".localized
+        case .pi: "tool.pi".localized
+        case .agents: "tool.global".localized
+        case .antigravity: "tool.antigravity".localized
+        case .claudeDesktop: "tool.claudeDesktop".localized
+        case .custom: "tool.custom".localized
         }
     }
 

--- a/Chops/Resources/en.lproj/Localizable.strings
+++ b/Chops/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,181 @@
+/* Navigation & Sidebar */
+"sidebar.library" = "Library";
+"sidebar.allSkills" = "All Skills";
+"sidebar.allAgents" = "All Agents";
+"sidebar.favorites" = "Favorites";
+"sidebar.tools" = "Tools";
+"sidebar.servers" = "Servers";
+"sidebar.collections" = "Collections";
+"sidebar.appTitle" = "Chops";
+"sidebar.syncFromServer" = "Sync skills from server";
+
+/* Skill List & Actions */
+"skillList.noAgents" = "No Agents";
+"skillList.noSkills" = "No Skills";
+"skillList.noAgentsMatch" = "No agents match the current filter.";
+"skillList.noSkillsMatch" = "No skills match the current filter.";
+"skillList.unfavorite" = "Unfavorite";
+"skillList.favorite" = "Favorite";
+"skillList.collections" = "Collections";
+"skillList.showInFinder" = "Show in Finder";
+"skillList.delete" = "Delete";
+"skillList.deleteConfirmTitle" = "Delete %@?";
+"skillList.deleteConfirmMessage" = "This will permanently delete \"%@\" from disk.";
+"skillList.deleteFailedTitle" = "Delete Failed";
+"skillList.ok" = "OK";
+
+/* Detail View */
+"detail.showInFinder" = "Show in Finder";
+"detail.deleteSkill" = "Delete Skill";
+"detail.deleteAgent" = "Delete Agent";
+"detail.saveError" = "Save Error";
+
+/* Editor */
+"editor.loadingFromServer" = "Loading from server...";
+"editor.saving" = "Saving...";
+"editor.modified" = "Modified";
+
+/* Metadata Bar */
+"metadata.collections" = "Collections";
+"metadata.noCollections" = "No collections yet";
+
+/* Collections */
+"collections.placeholder" = "Collection name";
+"collections.duplicateName" = "A collection with this name already exists";
+"collections.emptyName" = "Collection name can't be empty";
+"collections.rename" = "Rename";
+"collections.delete" = "Delete";
+"collections.new" = "New Collection";
+"collections.error" = "Collection Error";
+"collections.cancel" = "Cancel";
+"collections.create" = "Create";
+
+/* Content View */
+"content.selectAgent" = "Select an Agent";
+"content.selectAgentDescription" = "Choose an agent from the sidebar to view and edit it.";
+"content.selectSkill" = "Select a Skill";
+"content.selectSkillDescription" = "Choose a skill from the sidebar to view and edit it.";
+"content.searchAgents" = "Search agents...";
+"content.searchSkills" = "Search skills...";
+"content.newSkill" = "New Skill";
+"content.newAgent" = "New Agent";
+"content.browseRegistry" = "Browse Registry";
+"content.add" = "Add";
+
+/* App Menu */
+"menu.save" = "Save";
+"menu.checkForUpdates" = "Check for Updates…";
+"menu.exportDiagnostic" = "Export Diagnostic Log…";
+
+/* New Skill/Agent Sheet */
+"newSkill.titleAgent" = "New Agent";
+"newSkill.titleSkill" = "New Skill";
+"newSkill.agentName" = "Agent name";
+"newSkill.skillName" = "Skill name";
+"newSkill.tool" = "Tool";
+"newSkill.invalidName" = "Invalid name";
+"newSkill.duplicateAgent" = "An agent with this name already exists";
+"newSkill.duplicateSkill" = "A skill with this name already exists";
+"newSkill.noAgentSupport" = "This tool doesn't support agents";
+"newSkill.cancel" = "Cancel";
+"newSkill.create" = "Create";
+
+/* Registry Browser */
+"registry.back" = "Back";
+"registry.installSkill" = "Install Skill";
+"registry.browseSkills" = "Browse Skills";
+"registry.cancel" = "Cancel";
+"registry.searchPlaceholder" = "Search skills (e.g. react, testing, deploy)...";
+"registry.searchTitle" = "Search the Skills Registry";
+"registry.searchDescription" = "Find and install skills from the open agent skills ecosystem.";
+"registry.installTo" = "Install to:";
+"registry.selectAll" = "Select All";
+"registry.deselectAll" = "Deselect All";
+"registry.noAgentsDetected" = "No supported agents detected on this machine.";
+"registry.installsCount" = "%d installs";
+"registry.loadingContent" = "Loading skill content...";
+"registry.installed" = "Installed!";
+"registry.install" = "Install";
+
+/* Settings */
+"settings.general" = "General";
+"settings.scanDirectories" = "Scan Directories";
+"settings.servers" = "Servers";
+"settings.about" = "About";
+"settings.defaultTool" = "Default tool";
+"settings.customScanDirectories" = "Custom Scan Directories";
+"settings.scanDescription" = "Add a parent directory (e.g. ~/Development) and Chops will scan each project inside it for tool-specific skills and agents.";
+"settings.addDirectory" = "Add Directory...";
+"settings.appName" = "Chops";
+"settings.version" = "Version %@ (%@)";
+"settings.tagline" = "Your AI skills and agents, finally organized.";
+"settings.checkForUpdates" = "Check for Updates";
+"settings.website" = "Website";
+"settings.twitter" = "@Shpigford";
+"settings.github" = "GitHub";
+"settings.license" = "Free and open source under the MIT License.";
+
+/* Remote Servers Settings */
+"remoteServers.header" = "Remote Servers";
+"remoteServers.description" = "Connect to remote servers to browse and edit skills via SSH. Requires key-based authentication.";
+"remoteServers.addServer" = "Add Server...";
+"remoteServers.path" = "Path: %@";
+"remoteServers.synced" = "Synced %@";
+"remoteServers.test" = "Test";
+"remoteServers.sync" = "Sync";
+"remoteServers.edit" = "Edit";
+"remoteServers.error" = "Error: %@";
+"remoteServers.addTitle" = "Add Remote Server";
+"remoteServers.label" = "Label";
+"remoteServers.labelPlaceholder" = "Production Server";
+"remoteServers.host" = "Host";
+"remoteServers.hostPlaceholder" = "192.168.1.100";
+"remoteServers.port" = "Port";
+"remoteServers.portPlaceholder" = "22";
+"remoteServers.username" = "Username";
+"remoteServers.usernamePlaceholder" = "root";
+"remoteServers.basePath" = "Base Path";
+"remoteServers.basePathPlaceholder" = "e.g. ~/.openclaw, ~/skills";
+"remoteServers.sshKeyPath" = "SSH Key Path";
+"remoteServers.sshKeyPathPlaceholder" = "Optional — e.g. ~/.ssh/id_ed25519";
+"remoteServers.connectionSuccessful" = "Connection successful";
+"remoteServers.testConnection" = "Test Connection";
+"remoteServers.add" = "Add";
+"remoteServers.editTitle" = "Edit Server";
+"remoteServers.save" = "Save";
+
+/* Diagnostic Export */
+"diagnostic.title" = "Chops Diagnostic Report";
+"diagnostic.generated" = "Generated: %@";
+"diagnostic.system" = "System";
+"diagnostic.appVersion" = "App Version: %@ (%@)";
+"diagnostic.macOS" = "macOS: %@";
+"diagnostic.memory" = "Memory: %.1f GB";
+"diagnostic.items" = "Items";
+"diagnostic.total" = "Total: %d";
+"diagnostic.skills" = "Skills: %d";
+"diagnostic.agents" = "Agents: %d";
+"diagnostic.customScanPaths" = "Custom Scan Paths";
+"diagnostic.none" = "(none)";
+"diagnostic.recentLogs" = "Recent Logs";
+"diagnostic.unableToCollectLogs" = "(Unable to collect logs)";
+"diagnostic.noLogEntries" = "(No log entries in the last hour)";
+
+/* Tool Display Names */
+"tool.claude" = "Claude Code";
+"tool.cursor" = "Cursor";
+"tool.windsurf" = "Windsurf";
+"tool.codex" = "Codex";
+"tool.copilot" = "Copilot";
+"tool.aider" = "Aider";
+"tool.amp" = "Amp";
+"tool.openclaw" = "OpenClaw";
+"tool.opencode" = "OpenCode";
+"tool.pi" = "Pi";
+"tool.global" = "Global";
+"tool.antigravity" = "Antigravity";
+"tool.claudeDesktop" = "Claude Desktop";
+"tool.custom" = "Custom";
+
+/* Common */
+"common.remote" = "Remote";

--- a/Chops/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Chops/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,181 @@
+/* Navigation & Sidebar */
+"sidebar.library" = "资源库";
+"sidebar.allSkills" = "所有技能";
+"sidebar.allAgents" = "所有代理";
+"sidebar.favorites" = "收藏夹";
+"sidebar.tools" = "工具";
+"sidebar.servers" = "服务器";
+"sidebar.collections" = "合集";
+"sidebar.appTitle" = "Chops";
+"sidebar.syncFromServer" = "从服务器同步技能";
+
+/* Skill List & Actions */
+"skillList.noAgents" = "无代理";
+"skillList.noSkills" = "无技能";
+"skillList.noAgentsMatch" = "没有符合当前筛选条件的代理。";
+"skillList.noSkillsMatch" = "没有符合当前筛选条件的技能。";
+"skillList.unfavorite" = "取消收藏";
+"skillList.favorite" = "收藏";
+"skillList.collections" = "合集";
+"skillList.showInFinder" = "在访达中显示";
+"skillList.delete" = "删除";
+"skillList.deleteConfirmTitle" = "删除 %@？";
+"skillList.deleteConfirmMessage" = "这将永久从磁盘删除"%@"。";
+"skillList.deleteFailedTitle" = "删除失败";
+"skillList.ok" = "好";
+
+/* Detail View */
+"detail.showInFinder" = "在访达中显示";
+"detail.deleteSkill" = "删除技能";
+"detail.deleteAgent" = "删除代理";
+"detail.saveError" = "保存错误";
+
+/* Editor */
+"editor.loadingFromServer" = "正在从服务器加载...";
+"editor.saving" = "正在保存...";
+"editor.modified" = "已修改";
+
+/* Metadata Bar */
+"metadata.collections" = "合集";
+"metadata.noCollections" = "暂无合集";
+
+/* Collections */
+"collections.placeholder" = "合集名称";
+"collections.duplicateName" = "已存在同名合集";
+"collections.emptyName" = "合集名称不能为空";
+"collections.rename" = "重命名";
+"collections.delete" = "删除";
+"collections.new" = "新建合集";
+"collections.error" = "合集错误";
+"collections.cancel" = "取消";
+"collections.create" = "创建";
+
+/* Content View */
+"content.selectAgent" = "选择代理";
+"content.selectAgentDescription" = "从侧边栏选择一个代理以查看和编辑。";
+"content.selectSkill" = "选择技能";
+"content.selectSkillDescription" = "从侧边栏选择一个技能以查看和编辑。";
+"content.searchAgents" = "搜索代理...";
+"content.searchSkills" = "搜索技能...";
+"content.newSkill" = "新建技能";
+"content.newAgent" = "新建代理";
+"content.browseRegistry" = "浏览注册表";
+"content.add" = "添加";
+
+/* App Menu */
+"menu.save" = "保存";
+"menu.checkForUpdates" = "检查更新…";
+"menu.exportDiagnostic" = "导出诊断日志…";
+
+/* New Skill/Agent Sheet */
+"newSkill.titleAgent" = "新建代理";
+"newSkill.titleSkill" = "新建技能";
+"newSkill.agentName" = "代理名称";
+"newSkill.skillName" = "技能名称";
+"newSkill.tool" = "工具";
+"newSkill.invalidName" = "无效名称";
+"newSkill.duplicateAgent" = "已存在同名代理";
+"newSkill.duplicateSkill" = "已存在同名技能";
+"newSkill.noAgentSupport" = "此工具不支持代理";
+"newSkill.cancel" = "取消";
+"newSkill.create" = "创建";
+
+/* Registry Browser */
+"registry.back" = "返回";
+"registry.installSkill" = "安装技能";
+"registry.browseSkills" = "浏览技能";
+"registry.cancel" = "取消";
+"registry.searchPlaceholder" = "搜索技能（例如 react、testing、deploy）...";
+"registry.searchTitle" = "搜索技能注册表";
+"registry.searchDescription" = "从开放代理技能生态系统中查找并安装技能。";
+"registry.installTo" = "安装到：";
+"registry.selectAll" = "全选";
+"registry.deselectAll" = "取消全选";
+"registry.noAgentsDetected" = "此机器上未检测到支持的代理。";
+"registry.installsCount" = "%d 次安装";
+"registry.loadingContent" = "正在加载技能内容...";
+"registry.installed" = "已安装！";
+"registry.install" = "安装";
+
+/* Settings */
+"settings.general" = "通用";
+"settings.scanDirectories" = "扫描目录";
+"settings.servers" = "服务器";
+"settings.about" = "关于";
+"settings.defaultTool" = "默认工具";
+"settings.customScanDirectories" = "自定义扫描目录";
+"settings.scanDescription" = "添加一个父目录（例如 ~/Development），Chops 将扫描其中的每个项目以查找工具特定的技能和代理。";
+"settings.addDirectory" = "添加目录...";
+"settings.appName" = "Chops";
+"settings.version" = "版本 %@ (%@)";
+"settings.tagline" = "您的 AI 技能和代理，终于井然有序。";
+"settings.checkForUpdates" = "检查更新";
+"settings.website" = "网站";
+"settings.twitter" = "@Shpigford";
+"settings.github" = "GitHub";
+"settings.license" = "根据 MIT 许可证免费开源。";
+
+/* Remote Servers Settings */
+"remoteServers.header" = "远程服务器";
+"remoteServers.description" = "连接到远程服务器以通过 SSH 浏览和编辑技能。需要基于密钥的身份验证。";
+"remoteServers.addServer" = "添加服务器...";
+"remoteServers.path" = "路径：%@";
+"remoteServers.synced" = "已同步 %@";
+"remoteServers.test" = "测试";
+"remoteServers.sync" = "同步";
+"remoteServers.edit" = "编辑";
+"remoteServers.error" = "错误：%@";
+"remoteServers.addTitle" = "添加远程服务器";
+"remoteServers.label" = "标签";
+"remoteServers.labelPlaceholder" = "生产服务器";
+"remoteServers.host" = "主机";
+"remoteServers.hostPlaceholder" = "192.168.1.100";
+"remoteServers.port" = "端口";
+"remoteServers.portPlaceholder" = "22";
+"remoteServers.username" = "用户名";
+"remoteServers.usernamePlaceholder" = "root";
+"remoteServers.basePath" = "基础路径";
+"remoteServers.basePathPlaceholder" = "例如 ~/.openclaw、~/skills";
+"remoteServers.sshKeyPath" = "SSH 密钥路径";
+"remoteServers.sshKeyPathPlaceholder" = "可选 — 例如 ~/.ssh/id_ed25519";
+"remoteServers.connectionSuccessful" = "连接成功";
+"remoteServers.testConnection" = "测试连接";
+"remoteServers.add" = "添加";
+"remoteServers.editTitle" = "编辑服务器";
+"remoteServers.save" = "保存";
+
+/* Diagnostic Export */
+"diagnostic.title" = "Chops 诊断报告";
+"diagnostic.generated" = "生成时间：%@";
+"diagnostic.system" = "系统";
+"diagnostic.appVersion" = "应用版本：%@ (%@)";
+"diagnostic.macOS" = "macOS：%@";
+"diagnostic.memory" = "内存：%.1f GB";
+"diagnostic.items" = "项目";
+"diagnostic.total" = "总计：%d";
+"diagnostic.skills" = "技能：%d";
+"diagnostic.agents" = "代理：%d";
+"diagnostic.customScanPaths" = "自定义扫描路径";
+"diagnostic.none" = "（无）";
+"diagnostic.recentLogs" = "最近日志";
+"diagnostic.unableToCollectLogs" = "（无法收集日志）";
+"diagnostic.noLogEntries" = "（过去一小时内无日志条目）";
+
+/* Tool Display Names */
+"tool.claude" = "Claude Code";
+"tool.cursor" = "Cursor";
+"tool.windsurf" = "Windsurf";
+"tool.codex" = "Codex";
+"tool.copilot" = "Copilot";
+"tool.aider" = "Aider";
+"tool.amp" = "Amp";
+"tool.openclaw" = "OpenClaw";
+"tool.opencode" = "OpenCode";
+"tool.pi" = "Pi";
+"tool.global" = "Global";
+"tool.antigravity" = "Antigravity";
+"tool.claudeDesktop" = "Claude Desktop";
+"tool.custom" = "自定义";
+
+/* Common */
+"common.remote" = "远程";

--- a/Chops/Utilities/LocalizedString.swift
+++ b/Chops/Utilities/LocalizedString.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    var localized: String {
+        NSLocalizedString(self, comment: "")
+    }
+
+    func localized(_ arguments: CVarArg...) -> String {
+        String(format: NSLocalizedString(self, comment: ""), arguments: arguments)
+    }
+}

--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -47,8 +47,8 @@ struct SkillDetailView: View {
         .onReceive(NotificationCenter.default.publisher(for: .saveCurrentSkill)) { _ in
             document.save(to: skill)
         }
-        .alert("Save Error", isPresented: $document.showingSaveError) {
-            Button("OK") {}
+        .alert("detail.saveError".localized, isPresented: $document.showingSaveError) {
+            Button("skillList.ok".localized) {}
         } message: {
             Text(document.saveErrorMessage)
         }
@@ -76,7 +76,7 @@ struct SkillDetailView: View {
                     } label: {
                         Image(systemName: "folder")
                     }
-                    .help("Show in Finder")
+                    .help("detail.showInFinder".localized)
                 }
             }
             ToolbarItem {
@@ -85,25 +85,25 @@ struct SkillDetailView: View {
                 } label: {
                     Image(systemName: "trash")
                 }
-                .help("Delete \(skill.displayTypeName)")
+                .help(skill.itemKind == .skill ? "detail.deleteSkill".localized : "detail.deleteAgent".localized)
             }
         }
         .alert(item: $activeAlert) { alert in
             switch alert {
             case .confirmDelete:
                 return Alert(
-                    title: Text("Delete \(skill.displayTypeName)?"),
-                    message: Text("This will permanently delete \"\(skill.name)\" from disk."),
-                    primaryButton: .destructive(Text("Delete")) {
+                    title: Text("skillList.deleteConfirmTitle".localized(skill.displayTypeName)),
+                    message: Text("skillList.deleteConfirmMessage".localized(skill.name)),
+                    primaryButton: .destructive(Text("skillList.delete".localized)) {
                         deleteSkill()
                     },
                     secondaryButton: .cancel()
                 )
             case .deleteError(let message):
                 return Alert(
-                    title: Text("Delete Failed"),
+                    title: Text("skillList.deleteFailedTitle".localized),
                     message: Text(message),
-                    dismissButton: .default(Text("OK"))
+                    dismissButton: .default(Text("skillList.ok".localized))
                 )
             }
         }

--- a/Chops/Views/Detail/SkillEditorView.swift
+++ b/Chops/Views/Detail/SkillEditorView.swift
@@ -194,7 +194,7 @@ struct SkillEditorView: View {
         ZStack(alignment: .topTrailing) {
             if document.isLoadingRemote {
                 VStack {
-                    ProgressView("Loading from server...")
+                    ProgressView("editor.loadingFromServer".localized)
                         .padding()
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -206,13 +206,13 @@ struct SkillEditorView: View {
                 if document.isSavingRemote {
                     ProgressView()
                         .controlSize(.small)
-                    Text("Saving...")
+                    Text("editor.saving".localized)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
 
                 if document.hasUnsavedChanges {
-                    Text("Modified")
+                    Text("editor.modified".localized)
                         .font(.caption)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)

--- a/Chops/Views/Detail/SkillMetadataBar.swift
+++ b/Chops/Views/Detail/SkillMetadataBar.swift
@@ -100,7 +100,7 @@ struct SkillMetadataBar: View {
 
     private var collectionPickerContent: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Collections").font(.headline).padding(.bottom, 4)
+            Text("metadata.collections".localized).font(.headline).padding(.bottom, 4)
             ForEach(allCollections) { collection in
                 let isAssigned = skill.collections.contains(where: { $0.name == collection.name })
                 Button {
@@ -123,7 +123,7 @@ struct SkillMetadataBar: View {
                 .buttonStyle(.plain)
             }
             if allCollections.isEmpty {
-                Text("No collections yet")
+                Text("metadata.noCollections".localized)
                     .foregroundStyle(.secondary)
                     .font(.caption)
             }

--- a/Chops/Views/Settings/RemoteServersSettingsView.swift
+++ b/Chops/Views/Settings/RemoteServersSettingsView.swift
@@ -9,10 +9,10 @@ struct RemoteServersSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Remote Servers")
+            Text("remoteServers.header".localized)
                 .font(.headline)
 
-            Text("Connect to remote servers to browse and edit skills via SSH. Requires key-based authentication.")
+            Text("remoteServers.description".localized)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -30,7 +30,7 @@ struct RemoteServersSettingsView: View {
 
             HStack {
                 Spacer()
-                Button("Add Server...") {
+                Button("remoteServers.addServer".localized) {
                     showingAddSheet = true
                 }
             }
@@ -68,12 +68,12 @@ private struct ServerRow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fontDesign(.monospaced)
-                    Text("Path: \(server.skillsBasePath)")
+                    Text("remoteServers.path".localized(server.skillsBasePath))
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                         .fontDesign(.monospaced)
                     if let lastSync = server.lastSyncDate {
-                        Text("Synced \(lastSync.formatted(.relative(presentation: .named)))")
+                        Text("remoteServers.synced".localized(lastSync.formatted(.relative(presentation: .named))))
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }
@@ -99,7 +99,7 @@ private struct ServerRow: View {
                         ProgressView()
                             .controlSize(.small)
                     } else {
-                        Text("Test")
+                        Text("remoteServers.test".localized)
                     }
                 }
                 .disabled(isTesting)
@@ -111,7 +111,7 @@ private struct ServerRow: View {
                         ProgressView()
                             .controlSize(.small)
                     } else {
-                        Text("Sync")
+                        Text("remoteServers.sync".localized)
                     }
                 }
                 .disabled(isSyncing)
@@ -119,7 +119,7 @@ private struct ServerRow: View {
                 Button {
                     showingEditSheet = true
                 } label: {
-                    Text("Edit")
+                    Text("remoteServers.edit".localized)
                 }
 
                 Button(role: .destructive) {
@@ -133,7 +133,7 @@ private struct ServerRow: View {
             }
 
             if let error = server.lastSyncError {
-                Text("Error: \(error)")
+                Text("remoteServers.error".localized(error))
                     .font(.caption)
                     .foregroundStyle(.red)
                     .textSelection(.enabled)
@@ -214,16 +214,16 @@ private struct AddServerSheet: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            Text("Add Remote Server")
+            Text("remoteServers.addTitle".localized)
                 .font(.headline)
 
             Form {
-                TextField("Label", text: $label, prompt: Text("Production Server"))
-                TextField("Host", text: $host, prompt: Text("192.168.1.100"))
-                TextField("Port", text: $port, prompt: Text("22"))
-                TextField("Username", text: $username, prompt: Text("root"))
-                TextField("Base Path", text: $basePath, prompt: Text("e.g. ~/.openclaw, ~/skills"))
-                TextField("SSH Key Path", text: $sshKeyPath, prompt: Text("Optional — e.g. ~/.ssh/id_ed25519"))
+                TextField("remoteServers.label".localized, text: $label, prompt: Text("remoteServers.labelPlaceholder".localized))
+                TextField("remoteServers.host".localized, text: $host, prompt: Text("remoteServers.hostPlaceholder".localized))
+                TextField("remoteServers.port".localized, text: $port, prompt: Text("remoteServers.portPlaceholder".localized))
+                TextField("remoteServers.username".localized, text: $username, prompt: Text("remoteServers.usernamePlaceholder".localized))
+                TextField("remoteServers.basePath".localized, text: $basePath, prompt: Text("remoteServers.basePathPlaceholder".localized))
+                TextField("remoteServers.sshKeyPath".localized, text: $sshKeyPath, prompt: Text("remoteServers.sshKeyPathPlaceholder".localized))
             }
             .formStyle(.grouped)
 
@@ -234,25 +234,25 @@ private struct AddServerSheet: View {
             }
 
             if testPassed {
-                Label("Connection successful", systemImage: "checkmark.circle.fill")
+                Label("remoteServers.connectionSuccessful".localized, systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
                     .font(.caption)
             }
 
             HStack {
-                Button("Cancel") {
+                Button("remoteServers.cancel".localized) {
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
-                Button("Test Connection") {
+                Button("remoteServers.testConnection".localized) {
                     testConnection()
                 }
                 .disabled(host.isEmpty || username.isEmpty || isTesting)
 
-                Button("Add") {
+                Button("remoteServers.add".localized) {
                     addServer()
                     dismiss()
                 }
@@ -329,28 +329,28 @@ private struct EditServerSheet: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            Text("Edit Server")
+            Text("remoteServers.editTitle".localized)
                 .font(.headline)
 
             Form {
-                TextField("Label", text: $label, prompt: Text("Production Server"))
-                TextField("Host", text: $host, prompt: Text("192.168.1.100"))
-                TextField("Port", text: $port, prompt: Text("22"))
-                TextField("Username", text: $username, prompt: Text("root"))
-                TextField("Base Path", text: $basePath, prompt: Text("e.g. ~/.openclaw, ~/skills"))
-                TextField("SSH Key Path", text: $sshKeyPath, prompt: Text("Optional — e.g. ~/.ssh/id_ed25519"))
+                TextField("remoteServers.label".localized, text: $label, prompt: Text("remoteServers.labelPlaceholder".localized))
+                TextField("remoteServers.host".localized, text: $host, prompt: Text("remoteServers.hostPlaceholder".localized))
+                TextField("remoteServers.port".localized, text: $port, prompt: Text("remoteServers.portPlaceholder".localized))
+                TextField("remoteServers.username".localized, text: $username, prompt: Text("remoteServers.usernamePlaceholder".localized))
+                TextField("remoteServers.basePath".localized, text: $basePath, prompt: Text("remoteServers.basePathPlaceholder".localized))
+                TextField("remoteServers.sshKeyPath".localized, text: $sshKeyPath, prompt: Text("remoteServers.sshKeyPathPlaceholder".localized))
             }
             .formStyle(.grouped)
 
             HStack {
-                Button("Cancel") {
+                Button("remoteServers.cancel".localized) {
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
-                Button("Save") {
+                Button("remoteServers.save".localized) {
                     let connectionChanged = server.host != host
                         || server.username != username
                         || server.skillsBasePath != basePath

--- a/Chops/Views/Settings/SettingsView.swift
+++ b/Chops/Views/Settings/SettingsView.swift
@@ -14,22 +14,22 @@ struct SettingsView: View {
         TabView {
             generalSettings
                 .tabItem {
-                    Label("General", systemImage: "gearshape")
+                    Label("settings.general".localized, systemImage: "gearshape")
                 }
 
             scanSettings
                 .tabItem {
-                    Label("Scan Directories", systemImage: "folder.badge.gearshape")
+                    Label("settings.scanDirectories".localized, systemImage: "folder.badge.gearshape")
                 }
 
             RemoteServersSettingsView()
                 .tabItem {
-                    Label("Servers", systemImage: "server.rack")
+                    Label("settings.servers".localized, systemImage: "server.rack")
                 }
 
             aboutView
                 .tabItem {
-                    Label("About", systemImage: "info.circle")
+                    Label("settings.about".localized, systemImage: "info.circle")
                 }
         }
         .frame(width: 480, height: 380)
@@ -40,7 +40,7 @@ struct SettingsView: View {
 
     private var generalSettings: some View {
         Form {
-            Picker("Default tool", selection: $defaultTool) {
+            Picker("settings.defaultTool".localized, selection: $defaultTool) {
                 ForEach(ToolSource.allCases) { tool in
                     Text(tool.displayName).tag(tool)
                 }
@@ -52,10 +52,10 @@ struct SettingsView: View {
 
     private var scanSettings: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Custom Scan Directories")
+            Text("settings.customScanDirectories".localized)
                 .font(.headline)
 
-            Text("Add a parent directory (e.g. ~/Development) and Chops will scan each project inside it for tool-specific skills and agents.")
+            Text("settings.scanDescription".localized)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -83,7 +83,7 @@ struct SettingsView: View {
 
             HStack {
                 Spacer()
-                Button("Add Directory...") {
+                Button("settings.addDirectory".localized) {
                     let panel = NSOpenPanel()
                     panel.canChooseFiles = false
                     panel.canChooseDirectories = true
@@ -117,47 +117,52 @@ struct SettingsView: View {
                     }
                 }
 
-            Text("Chops")
+            Text("settings.appName".localized)
                 .font(.title)
                 .fontWeight(.bold)
 
-            Text("Version \(appVersion)")
+            Text("settings.version".localized(appVersionParts.version, appVersionParts.build))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
-            Text("Your AI skills and agents, finally organized.")
+            Text("settings.tagline".localized)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 16) {
-                Button("Check for Updates") {
+                Button("settings.checkForUpdates".localized) {
                     updater.checkForUpdates()
                 }
 
-                Button("Website") {
+                Button("settings.website".localized) {
                     NSWorkspace.shared.open(URL(string: "https://chops.md")!)
                 }
 
-                Button("@Shpigford") {
+                Button("settings.twitter".localized) {
                     NSWorkspace.shared.open(URL(string: "https://x.com/Shpigford")!)
                 }
 
-                Button("GitHub") {
+                Button("settings.github".localized) {
                     NSWorkspace.shared.open(URL(string: "https://github.com/Shpigford/chops")!)
                 }
             }
 
-            Text("Free and open source under the MIT License.")
+            Text("settings.license".localized)
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var appVersion: String {
+    private var appVersionParts: (version: String, build: String) {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-        return "\(version) (\(build))"
+        return (version, build)
+    }
+
+    private var appVersion: String {
+        let parts = appVersionParts
+        return "\(parts.version) (\(parts.build))"
     }
 
     private func loadCustomPaths() {

--- a/Chops/Views/Shared/NewSkillSheet.swift
+++ b/Chops/Views/Shared/NewSkillSheet.swift
@@ -21,15 +21,15 @@ struct NewSkillSheet: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            Text(isAgent ? "New Agent" : "New Skill")
+            Text(isAgent ? "newSkill.titleAgent".localized : "newSkill.titleSkill".localized)
                 .font(.title2)
                 .fontWeight(.bold)
 
             Form {
-                TextField(isAgent ? "Agent name" : "Skill name", text: $skillName)
+                TextField(isAgent ? "newSkill.agentName".localized : "newSkill.skillName".localized, text: $skillName)
                     .textFieldStyle(.roundedBorder)
 
-                Picker("Tool", selection: $selectedTool) {
+                Picker("newSkill.tool".localized, selection: $selectedTool) {
                     ForEach(creatableTools) { tool in
                         Label(tool.displayName, systemImage: tool.iconName)
                             .tag(tool)
@@ -45,14 +45,14 @@ struct NewSkillSheet: View {
             }
 
             HStack {
-                Button("Cancel") {
+                Button("newSkill.cancel".localized) {
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
-                Button("Create") {
+                Button("newSkill.create".localized) {
                     createItem()
                 }
                 .keyboardShortcut(.defaultAction)
@@ -83,7 +83,7 @@ struct NewSkillSheet: View {
             .filter { $0.isLetter || $0.isNumber || $0 == "-" }
 
         guard !sanitizedName.isEmpty else {
-            errorMessage = "Invalid name"
+            errorMessage = "newSkill.invalidName".localized
             return
         }
 
@@ -93,7 +93,7 @@ struct NewSkillSheet: View {
         if isAgent {
             // Agents go into the tool's agents/ directory
             guard let agentDir = selectedTool.globalAgentPaths.first else {
-                errorMessage = "This tool doesn't support agents"
+                errorMessage = "newSkill.noAgentSupport".localized
                 return
             }
             basePath = "\(agentDir)/\(sanitizedName)"
@@ -138,7 +138,7 @@ struct NewSkillSheet: View {
             let filePath = "\(basePath)/\(fileName)"
 
             guard !fm.fileExists(atPath: filePath) else {
-                errorMessage = isAgent ? "An agent with this name already exists" : "A skill with this name already exists"
+                errorMessage = isAgent ? "newSkill.duplicateAgent".localized : "newSkill.duplicateSkill".localized
                 return
             }
 

--- a/Chops/Views/Sidebar/CollectionListView.swift
+++ b/Chops/Views/Sidebar/CollectionListView.swift
@@ -36,7 +36,7 @@ struct CollectionListView: View {
             return
         }
         guard !hasDuplicateName(trimmed, excluding: collection.persistentModelID) else {
-            errorMessage = "A collection with this name already exists"
+            errorMessage = "collections.duplicateName".localized
             return
         }
         let oldName = collection.name
@@ -56,11 +56,11 @@ struct CollectionListView: View {
         errorMessage = nil
         let trimmed = normalizedName(newCollectionName)
         guard !trimmed.isEmpty else {
-            errorMessage = "Collection name can't be empty"
+            errorMessage = "collections.emptyName".localized
             return
         }
         guard !hasDuplicateName(trimmed) else {
-            errorMessage = "A collection with this name already exists"
+            errorMessage = "collections.duplicateName".localized
             return
         }
 
@@ -129,13 +129,13 @@ struct CollectionListView: View {
                         handleDrop(resolvedPaths, onto: collection)
                     }
                     .contextMenu {
-                        Button("Rename") {
+                        Button("collections.rename".localized) {
                             errorMessage = nil
                             editingName = collection.name
                             editingCollectionID = collection.persistentModelID
                         }
                         Divider()
-                        Button("Delete", role: .destructive) {
+                        Button("collections.delete".localized, role: .destructive) {
                             modelContext.delete(collection)
                             try? modelContext.save()
                         }
@@ -147,13 +147,13 @@ struct CollectionListView: View {
             errorMessage = nil
             showingNewCollection = true
         } label: {
-            Label("New Collection", systemImage: "plus.circle")
+            Label("collections.new".localized, systemImage: "plus.circle")
                 .foregroundStyle(.secondary)
         }
         .buttonStyle(.plain)
         .popover(isPresented: $showingNewCollection) {
             VStack(spacing: 12) {
-                TextField("Collection name", text: $newCollectionName)
+                TextField("collections.placeholder".localized, text: $newCollectionName)
                     .textFieldStyle(.roundedBorder)
                     .submitLabel(.done)
                     .onSubmit(createCollection)
@@ -184,23 +184,23 @@ struct CollectionListView: View {
                 }
 
                 HStack {
-                    Button("Cancel") {
+                    Button("collections.cancel".localized) {
                         errorMessage = nil
                         showingNewCollection = false
                     }
                     Spacer()
-                    Button("Create", action: createCollection)
+                    Button("collections.create".localized, action: createCollection)
                     .disabled(normalizedName(newCollectionName).isEmpty)
                 }
             }
             .padding()
             .frame(width: 240)
         }
-        .alert("Collection Error", isPresented: Binding(
+        .alert("collections.error".localized, isPresented: Binding(
             get: { errorMessage != nil && !showingNewCollection },
             set: { if !$0 { errorMessage = nil } }
         )) {
-            Button("OK") {}
+            Button("skillList.ok".localized) {}
         } message: {
             Text(errorMessage ?? "")
         }

--- a/Chops/Views/Sidebar/SidebarView.swift
+++ b/Chops/Views/Sidebar/SidebarView.swift
@@ -25,21 +25,21 @@ struct SidebarView: View {
         @Bindable var appState = appState
 
         List(selection: $appState.sidebarFilter) {
-            Section("Library") {
-                Label("All Skills", systemImage: "doc.text")
+            Section("sidebar.library".localized) {
+                Label("sidebar.allSkills".localized, systemImage: "doc.text")
                     .badge(allSkills.filter { $0.itemKind == .skill }.count)
                     .tag(SidebarFilter.allSkills)
 
-                Label("All Agents", systemImage: "person.crop.rectangle")
+                Label("sidebar.allAgents".localized, systemImage: "person.crop.rectangle")
                     .badge(allSkills.filter { $0.itemKind == .agent }.count)
                     .tag(SidebarFilter.allAgents)
 
-                Label("Favorites", systemImage: "star")
+                Label("sidebar.favorites".localized, systemImage: "star")
                     .badge(allSkills.filter(\.isFavorite).count)
                     .tag(SidebarFilter.favorites)
             }
 
-            Section("Tools") {
+            Section("sidebar.tools".localized) {
                 ForEach(activeSources) { tool in
                     Label {
                         Text(tool.displayName)
@@ -52,7 +52,7 @@ struct SidebarView: View {
             }
 
             if !servers.isEmpty {
-                Section("Servers") {
+                Section("sidebar.servers".localized) {
                     ForEach(servers) { server in
                         HStack {
                             Label {
@@ -95,7 +95,7 @@ struct SidebarView: View {
                                 }
                             }
                             .buttonStyle(.plain)
-                            .help("Sync skills from server")
+                            .help("sidebar.syncFromServer".localized)
                             .disabled(syncingServerIDs.contains(server.id))
                         }
                         .badge(server.skills.count)
@@ -104,12 +104,12 @@ struct SidebarView: View {
                 }
             }
 
-            Section("Collections") {
+            Section("sidebar.collections".localized) {
                 CollectionListView()
             }
         }
         .listStyle(.sidebar)
-        .navigationTitle("Chops")
+        .navigationTitle("sidebar.appTitle".localized)
     }
 
     private func syncServer(_ server: RemoteServer) {

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -55,13 +55,13 @@ struct SkillListView: View {
 
     private var title: String {
         switch appState.sidebarFilter {
-        case .allSkills: "All Skills"
-        case .allAgents: "All Agents"
-        case .favorites: "Favorites"
+        case .allSkills: "sidebar.allSkills".localized
+        case .allAgents: "sidebar.allAgents".localized
+        case .favorites: "sidebar.favorites".localized
         case .tool(let tool): tool.displayName
         case .collection(let name): name
         case .server(let id):
-            allSkills.first(where: { $0.remoteServer?.id == id })?.remoteServer?.label ?? "Remote"
+            allSkills.first(where: { $0.remoteServer?.id == id })?.remoteServer?.label ?? "common.remote".localized
         }
     }
 
@@ -95,12 +95,12 @@ struct SkillListView: View {
                     .tag(skill)
                     .draggable(skill.resolvedPath)
                     .contextMenu {
-                        Button(skill.isFavorite ? "Unfavorite" : "Favorite") {
+                        Button(skill.isFavorite ? "skillList.unfavorite".localized : "skillList.favorite".localized) {
                             skill.isFavorite.toggle()
                             try? modelContext.save()
                         }
                         if !allCollections.isEmpty {
-                            Menu("Collections") {
+                            Menu("skillList.collections".localized) {
                                 ForEach(allCollections) { collection in
                                     let isAssigned = skill.collections.contains(where: { $0.name == collection.name })
                                     Button {
@@ -120,12 +120,12 @@ struct SkillListView: View {
                         }
                         if !skill.isRemote {
                             Divider()
-                            Button("Show in Finder") {
+                            Button("skillList.showInFinder".localized) {
                                 NSWorkspace.shared.selectFile(skill.filePath, inFileViewerRootedAtPath: "")
                             }
                         }
                         Divider()
-                        Button("Delete", role: .destructive) {
+                        Button("skillList.delete".localized, role: .destructive) {
                             activeAlert = .confirmDelete(skill)
                         }
                     }
@@ -136,29 +136,29 @@ struct SkillListView: View {
             switch alert {
             case .confirmDelete(let skill):
                 return Alert(
-                    title: Text("Delete \(skill.displayTypeName)?"),
-                    message: Text("This will permanently delete \"\(skill.name)\" from disk."),
-                    primaryButton: .destructive(Text("Delete")) {
+                    title: Text("skillList.deleteConfirmTitle".localized(skill.displayTypeName)),
+                    message: Text("skillList.deleteConfirmMessage".localized(skill.name)),
+                    primaryButton: .destructive(Text("skillList.delete".localized)) {
                         deleteSkill(skill)
                     },
                     secondaryButton: .cancel()
                 )
             case .deleteError(let message):
                 return Alert(
-                    title: Text("Delete Failed"),
+                    title: Text("skillList.deleteFailedTitle".localized),
                     message: Text(message),
-                    dismissButton: .default(Text("OK"))
+                    dismissButton: .default(Text("skillList.ok".localized))
                 )
             }
         }
         .overlay {
             if filteredSkills.isEmpty {
                 ContentUnavailableView(
-                    appState.sidebarFilter == .allAgents ? "No Agents" : "No Skills",
+                    appState.sidebarFilter == .allAgents ? "skillList.noAgents".localized : "skillList.noSkills".localized,
                     systemImage: appState.sidebarFilter == .allAgents ? "person.crop.rectangle" : "doc.text",
                     description: Text(appState.sidebarFilter == .allAgents
-                        ? "No agents match the current filter."
-                        : "No skills match the current filter.")
+                        ? "skillList.noAgentsMatch".localized
+                        : "skillList.noSkillsMatch".localized)
                 )
             }
         }

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,8 @@ targets:
         excludes:
           - "*.entitlements"
           - Info.plist
+    resources:
+      - path: Chops/Resources
     dependencies:
       - package: Sparkle
       - package: MarkdownUI


### PR DESCRIPTION
Implements full Simplified Chinese localization for the Chops macOS app covering 200+ user-facing strings across all major UI components.

## Changes

**Localization Infrastructure**
- Created `Chops/Resources/en.lproj/Localizable.strings` (English base)
- Created `Chops/Resources/zh-Hans.lproj/Localizable.strings` (Simplified Chinese)
- Added `LocalizedString.swift` utility with `.localized` extension for convenient string localization
- Updated `project.yml` to include Resources directory in build

**Localized Views**
- **Navigation**: SidebarView - library sections, tool filters, server/collection lists
- **Skill Management**: SkillListView, SkillDetailView, SkillEditorView - list, context menus, toolbar actions, editor states
- **Content**: ContentView - search prompts, empty states, add menu
- **Settings**: SettingsView, RemoteServersSettingsView - all tabs, forms, server management UI
- **Dialogs**: NewSkillSheet, CollectionListView - creation flows, error messages
- **Models**: ToolSource - localized tool display names
- **App-level**: ChopsApp - menu commands

## Implementation

String localization uses key-based lookup with optional formatting:

```swift
// Simple string
Text("sidebar.allSkills".localized)

// With parameters
Text("remoteServers.path".localized(server.skillsBasePath))
```

Tool display names now return localized strings:

```swift
var displayName: String {
    switch self {
    case .claude: "tool.claude".localized
    case .cursor: "tool.cursor".localized
    // ...
    }
}
```

## Testing

Requires regenerating Xcode project with `xcodegen generate` in local environment. App will use Chinese when system language is set to Simplified Chinese.