### PR TITLE
feat: auto-save skill files on edit

### DIFF
--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -22,6 +22,7 @@ struct SkillDetailView: View {
     @AppStorage("preferPreview") private var preferPreview = false
     @State private var document = SkillEditorDocument()
     @State private var activeAlert: ActiveAlert?
+    @State private var autoSaveTask: Task<Void, Never>?
 
     var body: some View {
         @Bindable var document = document
@@ -42,7 +43,19 @@ struct SkillDetailView: View {
             document.load(from: skill)
         }
         .onChange(of: skill.filePath) {
+            autoSaveTask?.cancel()
             document.load(from: skill)
+        }
+        .onChange(of: document.editorContent) {
+            autoSaveTask?.cancel()
+            autoSaveTask = Task {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled, document.hasUnsavedChanges else { return }
+                document.save(to: skill)
+            }
+        }
+        .onDisappear {
+            autoSaveTask?.cancel()
         }
         .onReceive(NotificationCenter.default.publisher(for: .saveCurrentSkill)) { _ in
             document.save(to: skill)

--- a/Chops/Views/Detail/SkillEditorView.swift
+++ b/Chops/Views/Detail/SkillEditorView.swift
@@ -211,14 +211,6 @@ struct SkillEditorView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if document.hasUnsavedChanges {
-                    Text("Modified")
-                        .font(.caption)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(.orange.opacity(0.2), in: Capsule())
-                        .foregroundStyle(.orange)
-                }
             }
             .padding(12)
         }


### PR DESCRIPTION
## Summary
- Adds debounced auto-save that writes skill files to disk after 1 second of typing inactivity
- Removes the "Modified" badge since it's no longer meaningful with auto-save
- Cmd+S still works for immediate saves
- Cancels pending auto-save when switching skills or leaving the view to prevent stale writes

Fixes #59