### PR TITLE
feat: enable Cmd+F find bar in skill editor

### DIFF
--- a/Chops/App/ChopsApp.swift
+++ b/Chops/App/ChopsApp.swift
@@ -33,6 +33,7 @@ struct ChopsApp: App {
         }
         .modelContainer(sharedModelContainer)
         .commands {
+            TextEditingCommands()
             CommandGroup(replacing: .saveItem) {
                 Button("Save") {
                     NotificationCenter.default.post(name: .saveCurrentSkill, object: nil)


### PR DESCRIPTION
## Summary
- Adds `TextEditingCommands()` to the app's command group, enabling the standard macOS Find menu (Cmd+F, Cmd+G, etc.)
- The NSTextView editor already has `usesFindBar = true` configured — this wires up the missing menu commands so the find bar actually appears

Fixes #58