### PR TITLE
feat: cancel inflight request

### DIFF
--- a/Chops/Services/ACP/ACPClient.swift
+++ b/Chops/Services/ACP/ACPClient.swift
@@ -226,6 +226,18 @@ open class BaseACPAgent: ClientDelegate {
 
     func clearPendingWrites() { pendingWrites = [] }
 
+    /// Sends a session/cancel notification to the agent to interrupt the current turn.
+    func cancelPrompt() {
+        guard let client = acpClient, let sid = sessionId else { return }
+        Task {
+            do {
+                try await client.cancelSession(sessionId: sid)
+            } catch {
+                acpLog.error("Cancel failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
     // MARK: - Permission
 
     func parkPermissionRequest(title: String, options: [PermissionOption]) async throws -> RequestPermissionResponse {

--- a/Chops/Views/Shared/ComposePanel.swift
+++ b/Chops/Views/Shared/ComposePanel.swift
@@ -605,27 +605,38 @@ struct ComposePanel: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.secondary.opacity(0.25)))
 
-            Button {
-                sendMessage()
-            } label: {
-                Group {
-                    if isProcessing {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Image(systemName: "paperplane.fill")
-                    }
+            if isProcessing {
+                Button {
+                    acpClient?.cancelPrompt()
+                } label: {
+                    Image(systemName: "stop.fill")
+                        .font(.body)
+                        .foregroundStyle(.white)
+                        .frame(width: 36)
+                        .frame(maxHeight: .infinity)
+                        .background(Color.red.opacity(0.8))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
-                .font(.body)
-                .foregroundStyle(.white)
-                .frame(width: 36)
-                .frame(maxHeight: .infinity)
-                .background(sendDisabled ? Color.accentColor.opacity(0.4) : Color.accentColor)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .buttonStyle(.plain)
+                .help("Stop (⌘.)")
+                .keyboardShortcut(".", modifiers: .command)
+            } else {
+                Button {
+                    sendMessage()
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                        .font(.body)
+                        .foregroundStyle(.white)
+                        .frame(width: 36)
+                        .frame(maxHeight: .infinity)
+                        .background(sendDisabled ? Color.accentColor.opacity(0.4) : Color.accentColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+                .disabled(sendDisabled)
+                .keyboardShortcut(.return, modifiers: .command)
+                .help("Send (⌘↩)")
             }
-            .buttonStyle(.plain)
-            .disabled(sendDisabled)
-            .keyboardShortcut(.return, modifiers: .command)
-            .help("Send (⌘↩)")
         }
         .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal, 12)
@@ -755,7 +766,7 @@ struct ComposePanel: View {
                     return
                 }
                 let prompt = buildPrompt(text: text, originalContent: original)
-                try await client.prompt(prompt)  // agent sets isProcessing true → false via defer
+                try await client.prompt(prompt)
                 isFirstTurn = false
 
                 let raw = client.responseText


### PR DESCRIPTION
### Summary

- Adds a `cancelPrompt()` method to `BaseACPAgent` that sends a `session/cancel` JSON-RPC notification to the agent process via the ACP SDK's `client.cancelSession(sessionId:)`.
- Replaces the static send button in `ComposePanel` with a context-aware toggle: while the agent is processing, the button becomes a red stop button (`⌘.`); once processing ends it reverts to the send button (`⌘↩`).
- Cancel failures are logged to the ACP log rather than silently dropped.

### Not in this PR

- Concurrent-send race (`isProcessing` not set until inside `prompt()`) — tracked separately.