### PR TITLE
feat: floating AI compose button with proper cursor handling

### DIFF
--- a/Chops/Views/Detail/ChopsTextView.swift
+++ b/Chops/Views/Detail/ChopsTextView.swift
@@ -4,6 +4,15 @@ final class ChopsTextView: NSTextView {
 
     // MARK: - Cursor
 
+    override func mouseMoved(with event: NSEvent) {
+        // If another view (e.g. a floating button) is in front at this point, don't set the I-beam.
+        if let hitView = window?.contentView?.hitTest(event.locationInWindow),
+           hitView !== self, !(hitView is NSClipView) {
+            return
+        }
+        super.mouseMoved(with: event)
+    }
+
     override func didAddSubview(_ subview: NSView) {
         super.didAddSubview(subview)
         if let indicator = subview as? NSTextInsertionIndicator {

--- a/Chops/Views/Detail/SkillDetailView.swift
+++ b/Chops/Views/Detail/SkillDetailView.swift
@@ -1,6 +1,64 @@
 import SwiftUI
 import SwiftData
 
+/// Transparent NSView overlay that intercepts AppKit hit-testing so it owns
+/// cursor management (pointing hand) and click handling, beating NSTextView's
+/// aggressive I-beam cursor.
+private struct ClickableCursorOverlay: NSViewRepresentable {
+    var action: () -> Void
+
+    func makeNSView(context: Context) -> OverlayNSView {
+        let view = OverlayNSView()
+        view.onTap = action
+        return view
+    }
+
+    func updateNSView(_ nsView: OverlayNSView, context: Context) {
+        nsView.onTap = action
+    }
+
+    final class OverlayNSView: NSView {
+        var onTap: (() -> Void)?
+        private var area: NSTrackingArea?
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let area { removeTrackingArea(area) }
+            area = NSTrackingArea(
+                rect: bounds,
+                options: [.mouseEnteredAndExited, .cursorUpdate, .activeInKeyWindow],
+                owner: self
+            )
+            addTrackingArea(area!)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            let local = convert(point, from: superview)
+            return bounds.contains(local) ? self : nil
+        }
+
+        override func cursorUpdate(with event: NSEvent) {
+            NSCursor.pointingHand.set()
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            NSCursor.pointingHand.set()
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            NSCursor.arrow.set()
+        }
+
+        override func mouseDown(with event: NSEvent) {
+            onTap?()
+        }
+
+        override func resetCursorRects() {
+            addCursorRect(bounds, cursor: .pointingHand)
+        }
+    }
+}
+
 struct SkillDetailView: View {
     private enum ActiveAlert: Identifiable {
         case confirmDelete
@@ -29,10 +87,16 @@ struct SkillDetailView: View {
         @Bindable var document = document
 
         VStack(spacing: 0) {
-            if preferPreview {
-                SkillPreviewView(content: document.editorContent)
-            } else {
-                SkillEditorView(document: document)
+            ZStack(alignment: .bottomTrailing) {
+                if preferPreview {
+                    SkillPreviewView(content: document.editorContent)
+                } else {
+                    SkillEditorView(document: document)
+                }
+
+                if !showingComposePanel {
+                    composeFloatingButton
+                }
             }
 
             // Inline compose panel
@@ -100,14 +164,6 @@ struct SkillDetailView: View {
                 }
                 .pickerStyle(.segmented)
             }
-            ToolbarItemGroup {
-                Button {
-                    showingComposePanel.toggle()
-                } label: {
-                    Image(systemName: showingComposePanel ? "sparkles.rectangle.stack.fill" : "sparkles")
-                }
-                .help(showingComposePanel ? "Hide Compose Panel" : "Compose with AI")
-            }
             ToolbarItem {
                 Button {
                     skill.isFavorite.toggle()
@@ -155,6 +211,18 @@ struct SkillDetailView: View {
                 )
             }
         }
+    }
+
+    private var composeFloatingButton: some View {
+        Image(systemName: "sparkles")
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: 36, height: 36)
+            .background(Circle().fill(Color.accentColor))
+            .shadow(color: .black.opacity(0.25), radius: 4, y: 2)
+            .overlay(ClickableCursorOverlay(action: { [self] in showingComposePanel.toggle() }))
+            .help("Compose with AI")
+            .padding(16)
     }
 
     private func deleteSkill() {

--- a/Chops/Views/Shared/ComposePanel.swift
+++ b/Chops/Views/Shared/ComposePanel.swift
@@ -697,6 +697,8 @@ struct ComposePanel: View {
             isVisible = false
         } label: {
             Image(systemName: "xmark")
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Moves the AI compose button from the toolbar to a floating circle in the bottom-right corner of the skill editor
- Fixes I-beam cursor showing over the button by using AppKit-level hit testing (`ClickableCursorOverlay`) and suppressing NSTextView's `mouseMoved:` when a sibling view is in front
- Enlarges the compose panel close (X) button hit area from icon-only to 28×28

## Test plan
- [ ] Hover over the floating AI button — cursor should be pointing hand, not I-beam
- [ ] Click the floating AI button — compose panel should open
- [ ] Button should hide when compose panel is open
- [ ] Close button (X) in compose panel should be easy to click
- [ ] Normal text editing cursor behavior unaffected elsewhere in the editor