### PR TITLE
fix: show Global tool source in sidebar when skills exist

### DIFF
--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -22,7 +22,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
     /// Whether this tool should appear in the sidebar tools list.
     var listable: Bool {
         switch self {
-        case .custom, .claudeDesktop, .agents, .aider:
+        case .custom, .claudeDesktop, .aider:
             return false
         default:
             return true


### PR DESCRIPTION
## Summary

- The `listable` property introduced in #69 (ACP support) accidentally excluded `.agents` from the sidebar by grouping it with `.custom`, `.claudeDesktop`, and `.aider` as non-listable. Before #69, `.agents` had been visible in the sidebar since #42.
- Users with skills in `~/.agents/skills/` (created manually or via "Make Global") could not see or filter by the Global tool in the sidebar, even though those skills were scanned correctly.
- Removes `.agents` from the non-listable cases so it appears in the sidebar Tools section like any other installed tool.

## Test plan

- [ ] Create at least one skill in `~/.agents/skills/` (or use "Make Global" on an existing skill)
- [ ] Launch the app and verify "Global" appears in the sidebar under Tools
- [ ] Click it and confirm it filters to only skills with `.agents` in their `toolSources`
- [ ] Verify other non-listable tools (`.custom`, `.claudeDesktop`, `.aider`) still do not appear


Made with [Cursor](https://cursor.com)