### PR TITLE
fix: Defer AI Assist file writes until user accepts the diff (#84)

### DIFF
--- a/Chops.xcodeproj/project.pbxproj
+++ b/Chops.xcodeproj/project.pbxproj
@@ -16,9 +16,12 @@
 		309B12E0B72A22C9772BBC99 /* ChopsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2787064DC7DF112E70C4E4D0 /* ChopsApp.swift */; };
 		322C22C23073C29FC0C6098D /* MarkdownMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947EAED7376B7762A373EF08 /* MarkdownMessageView.swift */; };
 		331F55021A7E6C9F0B666514 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 4338FC540625A275BBC9AAC9 /* Sparkle */; };
+		338B2D758146EF36F72D8D82 /* MCPDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266B85AEA99EB82A2622A834 /* MCPDetailView.swift */; };
+		3966FE72FE9CA8827080E86E /* MCPListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40C11729CB927FB906E39DD /* MCPListView.swift */; };
 		3BF88469DCE0B56DD15DDB09 /* ACPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DAD83C176F3A71A5B360BFD /* ACPClient.swift */; };
 		3F0ED402E77D8D25C600BAED /* TemplateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12C5CD1627D4EFF58AEF4F71 /* TemplateManager.swift */; };
 		480681BAD19F7CAF6AE154A2 /* RemoteServersSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E684304D1723CA691F40335B /* RemoteServersSettingsView.swift */; };
+		4E15E33BC6DB0C8D1A901884 /* MCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2EAC981D1DE54C6A130984 /* MCPServer.swift */; };
 		53C393C13E30EC439317509F /* ToolBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B6AE242CAD6A285DD57079 /* ToolBadge.swift */; };
 		590A98554CAF058BC006CC53 /* ACPAgentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBC9E32924CF525F1C96BAE /* ACPAgentFactory.swift */; };
 		5B81DED237A60776ADB04134 /* RemoteServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3314080A44DEB895223E36D5 /* RemoteServer.swift */; };
@@ -52,6 +55,7 @@
 		BFF9964529E6C48F4F7BCB97 /* MarkdownSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135976FA0E8358E099157DE1 /* MarkdownSyntaxHighlighter.swift */; };
 		C30BEAE03E54BD36F257A925 /* ToolFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5774429CCE83C2AFBE046C /* ToolFilterView.swift */; };
 		C6CFF37CC0B155E8846344A4 /* ChopsIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 04C3C644B72DD508A7CBC403 /* ChopsIcon.icon */; };
+		C93C75003EB3B07E44C89539 /* MCPScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA99672C2C0108B368F1CE7 /* MCPScanner.swift */; };
 		C983C685C6296C2EF73CE57D /* CursorACPAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07899C351E63B32277272A59 /* CursorACPAgent.swift */; };
 		CBD8FECF1C5A453C8B021665 /* FrontmatterParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C77C5B30E6C885B39444E5B /* FrontmatterParser.swift */; };
 		CCD92CB102DFA0965D6AFDB5 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF7822031FD82A28978D9C5 /* SidebarView.swift */; };
@@ -80,8 +84,10 @@
 		17F7FE50C96124BA4EE43A6F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		181FD0056E54DEB3957FB4DC /* WizardTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WizardTemplate.swift; sourceTree = "<group>"; };
 		231C267216AF1BCA8628B667 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		266B85AEA99EB82A2622A834 /* MCPDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDetailView.swift; sourceTree = "<group>"; };
 		2787064DC7DF112E70C4E4D0 /* ChopsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChopsApp.swift; sourceTree = "<group>"; };
 		27D6ED655F951177D2152351 /* Skill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Skill.swift; sourceTree = "<group>"; };
+		2BA99672C2C0108B368F1CE7 /* MCPScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPScanner.swift; sourceTree = "<group>"; };
 		2CF7822031FD82A28978D9C5 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		2D07C2CD05E172DB71F63033 /* ThinkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingView.swift; sourceTree = "<group>"; };
 		2D9B5801101BA69BB84EE28D /* ChopsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChopsSettings.swift; sourceTree = "<group>"; };
@@ -89,6 +95,7 @@
 		3314080A44DEB895223E36D5 /* RemoteServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServer.swift; sourceTree = "<group>"; };
 		372FA72F2C179B79470DF86A /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		3A4F680B33C74A38FCF5ADD5 /* MDCParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDCParser.swift; sourceTree = "<group>"; };
+		3C2EAC981D1DE54C6A130984 /* MCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServer.swift; sourceTree = "<group>"; };
 		4CA102A49ACFB23BC15794F8 /* CollectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListView.swift; sourceTree = "<group>"; };
 		511C5A2149EFF77BDA7D4692 /* ACPLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLogger.swift; sourceTree = "<group>"; };
 		5155D141EF812A3FE9ADF59C /* SkillParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillParser.swift; sourceTree = "<group>"; };
@@ -112,6 +119,7 @@
 		9BBC9E32924CF525F1C96BAE /* ACPAgentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentFactory.swift; sourceTree = "<group>"; };
 		9C052B94D025127C9823E7BC /* ACPSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSettingsView.swift; sourceTree = "<group>"; };
 		9FC9D3E83D8640CC258CF361 /* SkillRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillRegistry.swift; sourceTree = "<group>"; };
+		A40C11729CB927FB906E39DD /* MCPListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPListView.swift; sourceTree = "<group>"; };
 		A7B6AE242CAD6A285DD57079 /* ToolBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBadge.swift; sourceTree = "<group>"; };
 		A924245DDDA4C6A59BE15567 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		AA64A368BBF950CD36C4F495 /* SkillListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillListView.swift; sourceTree = "<group>"; };
@@ -178,6 +186,15 @@
 			path = Chops;
 			sourceTree = "<group>";
 		};
+		1A63A1808F90A76846892103 /* MCP */ = {
+			isa = PBXGroup;
+			children = (
+				266B85AEA99EB82A2622A834 /* MCPDetailView.swift */,
+				A40C11729CB927FB906E39DD /* MCPListView.swift */,
+			);
+			path = MCP;
+			sourceTree = "<group>";
+		};
 		1B016A7C37052B1801FCFD6A /* Shared */ = {
 			isa = PBXGroup;
 			children = (
@@ -221,6 +238,7 @@
 			isa = PBXGroup;
 			children = (
 				96A2A820C082754BBFB0237D /* Detail */,
+				1A63A1808F90A76846892103 /* MCP */,
 				40FF74A5B2D0A1E16B14B7A4 /* Settings */,
 				1B016A7C37052B1801FCFD6A /* Shared */,
 				95530102A99D9A389717E414 /* Sidebar */,
@@ -243,6 +261,7 @@
 			children = (
 				F45D5C8E8C732B2F4A867E43 /* AppLogger.swift */,
 				CAD26AA4787A2E0CDC86AADC /* FileWatcher.swift */,
+				2BA99672C2C0108B368F1CE7 /* MCPScanner.swift */,
 				7FFC47BDE92105F4736B379F /* SearchService.swift */,
 				5155D141EF812A3FE9ADF59C /* SkillParser.swift */,
 				9FC9D3E83D8640CC258CF361 /* SkillRegistry.swift */,
@@ -261,6 +280,7 @@
 				907E59B064AB8366B60BF611 /* AgentTarget.swift */,
 				2D9B5801101BA69BB84EE28D /* ChopsSettings.swift */,
 				C9AFE1AF02B0F8057791C2A9 /* Collection.swift */,
+				3C2EAC981D1DE54C6A130984 /* MCPServer.swift */,
 				3314080A44DEB895223E36D5 /* RemoteServer.swift */,
 				B1F8AA042D5D8A9F92F35CA3 /* SchemaVersions.swift */,
 				27D6ED655F951177D2152351 /* Skill.swift */,
@@ -426,6 +446,10 @@
 				99EE8F6124FE91AC9576D6FD /* FileWatcher.swift in Sources */,
 				CBD8FECF1C5A453C8B021665 /* FrontmatterParser.swift in Sources */,
 				A0862ECC573FDC0AA7CB9950 /* LibrarySettingsView.swift in Sources */,
+				338B2D758146EF36F72D8D82 /* MCPDetailView.swift in Sources */,
+				3966FE72FE9CA8827080E86E /* MCPListView.swift in Sources */,
+				C93C75003EB3B07E44C89539 /* MCPScanner.swift in Sources */,
+				4E15E33BC6DB0C8D1A901884 /* MCPServer.swift in Sources */,
 				7FD1DE6640F9339D5E97E09A /* MDCParser.swift in Sources */,
 				322C22C23073C29FC0C6098D /* MarkdownMessageView.swift in Sources */,
 				E7ED248D6F94C1B1DEF1E8BA /* MarkdownRenderer.swift in Sources */,

--- a/Chops/App/AppState.swift
+++ b/Chops/App/AppState.swift
@@ -11,6 +11,7 @@ final class AppState {
     var sidebarFilter: SidebarFilter = .allSkills
     /// Filter by item kind within a tool view (nil = show all)
     var toolKindFilter: ItemKind?
+    var selectedMCPServer: MCPServer?
 }
 
 enum SidebarFilter: Hashable {
@@ -21,4 +22,5 @@ enum SidebarFilter: Hashable {
     case tool(ToolSource)
     case collection(String)
     case server(String)
+    case allMCPServers
 }

--- a/Chops/App/ChopsApp.swift
+++ b/Chops/App/ChopsApp.swift
@@ -17,7 +17,7 @@ struct ChopsApp: App {
     }
 
     var sharedModelContainer: ModelContainer = {
-        let schema = Schema([Skill.self, SkillCollection.self, RemoteServer.self])
+        let schema = Schema([Skill.self, SkillCollection.self, RemoteServer.self, MCPServer.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
         do {

--- a/Chops/App/ContentView.swift
+++ b/Chops/App/ContentView.swift
@@ -6,7 +6,9 @@ struct ContentView: View {
     @Environment(AppState.self) private var appState
     @Query(sort: \Skill.name) private var skills: [Skill]
     @State private var scanner: SkillScanner?
+    @State private var mcpScanner: MCPScanner?
     @State private var fileWatcher: FileWatcher?
+    @State private var mcpFileWatcher: FileWatcher?
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
@@ -15,9 +17,23 @@ struct ContentView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarView()
         } content: {
-            SkillListView()
+            if appState.sidebarFilter == .allMCPServers {
+                MCPListView()
+            } else {
+                SkillListView()
+            }
         } detail: {
-            if let skill = appState.selectedSkill {
+            if appState.sidebarFilter == .allMCPServers {
+                if let server = appState.selectedMCPServer {
+                    MCPDetailView(server: server)
+                } else {
+                    ContentUnavailableView(
+                        "Select a Server",
+                        systemImage: "point.3.connected.trianglepath.dotted",
+                        description: Text("Choose an MCP server to view its configuration.")
+                    )
+                }
+            } else if let skill = appState.selectedSkill {
                 SkillDetailView(skill: skill)
             } else {
                 ContentUnavailableView(
@@ -43,6 +59,7 @@ struct ContentView: View {
         .frame(minWidth: 900, minHeight: 500)
         .onReceive(NotificationCenter.default.publisher(for: .customScanPathsChanged)) { _ in
             scanner?.scanAll()
+            mcpScanner?.scanAll()
         }
     }
 
@@ -80,6 +97,33 @@ struct ContentView: View {
         watcher.watchDirectories(allPaths)
         self.fileWatcher = watcher
         AppLogger.ui.notice("File watchers active on \(allPaths.count) directories")
+
+        // MCP server scanning
+        let mcpScanner = MCPScanner(modelContext: modelContext)
+        self.mcpScanner = mcpScanner
+        mcpScanner.scanAll()
+
+        var mcpPaths: [String] = []
+        for tool in ToolSource.allCases {
+            for path in tool.mcpConfigPaths {
+                let expanded = (path as NSString).expandingTildeInPath
+                if fm.fileExists(atPath: expanded) {
+                    mcpPaths.append(expanded)
+                }
+            }
+        }
+        let customPaths = UserDefaults.standard.stringArray(forKey: "customScanPaths") ?? []
+        for basePath in customPaths where fm.fileExists(atPath: basePath) {
+            mcpPaths.append(basePath)
+        }
+        if !mcpPaths.isEmpty {
+            let mcpWatcher = FileWatcher { _ in
+                mcpScanner.scanAll()
+            }
+            mcpWatcher.watchDirectories(mcpPaths)
+            self.mcpFileWatcher = mcpWatcher
+            AppLogger.ui.notice("MCP file watchers active on \(mcpPaths.count) paths")
+        }
 
         // Sync remote servers in the background
         Task {

--- a/Chops/Models/MCPServer.swift
+++ b/Chops/Models/MCPServer.swift
@@ -1,0 +1,97 @@
+import SwiftData
+import Foundation
+
+@Model
+final class MCPServer {
+    /// Composite key: "toolSource:configFilePath:name"
+    @Attribute(.unique) var id: String
+    var name: String
+    var toolSourceRaw: String
+    var configFilePath: String
+    var transportType: String
+
+    var command: String?
+    var argsData: Data?
+    var envData: Data?
+
+    var url: String?
+    var headersData: Data?
+
+    var isEnabled: Bool
+
+    // MARK: - Computed
+
+    var toolSource: ToolSource {
+        ToolSource(rawValue: toolSourceRaw) ?? .custom
+    }
+
+    var args: [String] {
+        get {
+            guard let data = argsData else { return [] }
+            return (try? JSONDecoder().decode([String].self, from: data)) ?? []
+        }
+        set {
+            argsData = try? JSONEncoder().encode(newValue)
+        }
+    }
+
+    var env: [String: String] {
+        get {
+            guard let data = envData else { return [:] }
+            return (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
+        }
+        set {
+            envData = try? JSONEncoder().encode(newValue)
+        }
+    }
+
+    var headers: [String: String] {
+        get {
+            guard let data = headersData else { return [:] }
+            return (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
+        }
+        set {
+            headersData = try? JSONEncoder().encode(newValue)
+        }
+    }
+
+    var displayTransport: String {
+        switch transportType {
+        case "stdio": "stdio"
+        case "http": "HTTP"
+        case "sse": "SSE"
+        default: transportType
+        }
+    }
+
+    // MARK: - Init
+
+    init(
+        name: String,
+        toolSource: ToolSource,
+        configFilePath: String,
+        transportType: String,
+        command: String? = nil,
+        args: [String] = [],
+        env: [String: String] = [:],
+        url: String? = nil,
+        headers: [String: String] = [:],
+        isEnabled: Bool = true
+    ) {
+        self.id = "\(toolSource.rawValue):\(configFilePath):\(name)"
+        self.name = name
+        self.toolSourceRaw = toolSource.rawValue
+        self.configFilePath = configFilePath
+        self.transportType = transportType
+        self.command = command
+        self.argsData = try? JSONEncoder().encode(args)
+        self.envData = try? JSONEncoder().encode(env)
+        self.url = url
+        self.headersData = try? JSONEncoder().encode(headers)
+        self.isEnabled = isEnabled
+    }
+
+    static func makeID(toolSource: ToolSource, configFilePath: String, name: String) -> String {
+        "\(toolSource.rawValue):\(configFilePath):\(name)"
+    }
+}

--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -255,6 +255,22 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         return paths.contains { fm.fileExists(atPath: $0) }
     }
 
+    var mcpConfigPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        switch self {
+        case .claude:
+            return ["\(home)/.claude.json"]
+        case .claudeDesktop:
+            return ["\(home)/Library/Application Support/Claude/claude_desktop_config.json"]
+        case .cursor:
+            return ["\(home)/.cursor/mcp.json"]
+        case .copilot:
+            return ["\(home)/.vscode/mcp.json"]
+        default:
+            return []
+        }
+    }
+
     private static func cliBinaryExists(_ name: String) -> Bool {
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser.path

--- a/Chops/Services/MCPScanner.swift
+++ b/Chops/Services/MCPScanner.swift
@@ -1,0 +1,208 @@
+import Foundation
+import SwiftData
+import os
+
+struct ScannedMCPData: Sendable {
+    let id: String
+    let name: String
+    let toolSource: ToolSource
+    let configFilePath: String
+    let transportType: String
+    let command: String?
+    let args: [String]
+    let env: [String: String]
+    let url: String?
+    let headers: [String: String]
+    let isEnabled: Bool
+}
+
+@Observable
+final class MCPScanner {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func scanAll() {
+        let start = CFAbsoluteTimeGetCurrent()
+        AppLogger.scanning.notice("MCP scan started")
+
+        let customPaths = UserDefaults.standard.stringArray(forKey: "customScanPaths") ?? []
+        Task.detached { [weak self] in
+            let results = Self.collectAllMCPServers(customPaths: customPaths)
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            AppLogger.scanning.notice("MCP collection done: \(results.count) servers in \(String(format: "%.2f", elapsed))s")
+
+            await MainActor.run {
+                guard let self else { return }
+                self.applyResults(results)
+                let total = CFAbsoluteTimeGetCurrent() - start
+                AppLogger.scanning.notice("MCP scan complete: \(results.count) servers applied in \(String(format: "%.2f", total))s")
+            }
+        }
+    }
+
+    // MARK: - Collection (off main thread)
+
+    /// Project-level MCP config paths to probe inside each project directory.
+    private static let projectMCPProbes: [(subpath: String, tool: ToolSource)] = [
+        (".cursor/mcp.json", .cursor),
+        (".vscode/mcp.json", .copilot),
+        (".claude/mcp.json", .claude),
+    ]
+
+    private static func collectAllMCPServers(customPaths: [String]) -> [ScannedMCPData] {
+        var results: [ScannedMCPData] = []
+        let fm = FileManager.default
+
+        // Global tool configs
+        for tool in ToolSource.allCases {
+            for configPath in tool.mcpConfigPaths {
+                let expanded = (configPath as NSString).expandingTildeInPath
+                guard fm.fileExists(atPath: expanded) else { continue }
+                collectFromConfig(path: expanded, toolSource: tool, into: &results)
+            }
+        }
+
+        // Project-level configs inside custom scan directories
+        for basePath in customPaths {
+            guard let projects = try? fm.contentsOfDirectory(
+                at: URL(fileURLWithPath: basePath),
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            for project in projects {
+                var isDir: ObjCBool = false
+                fm.fileExists(atPath: project.path, isDirectory: &isDir)
+                guard isDir.boolValue else { continue }
+
+                for probe in projectMCPProbes {
+                    let configPath = project.appendingPathComponent(probe.subpath).path
+                    guard fm.fileExists(atPath: configPath) else { continue }
+                    collectFromConfig(path: configPath, toolSource: probe.tool, into: &results)
+                }
+            }
+        }
+
+        return results
+    }
+
+    private static func collectFromConfig(path: String, toolSource: ToolSource, into results: inout [ScannedMCPData]) {
+        guard let data = FileManager.default.contents(atPath: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            AppLogger.scanning.warning("Failed to parse MCP config: \(path)")
+            return
+        }
+
+        if let servers = json["mcpServers"] as? [String: [String: Any]] {
+            for (name, config) in servers {
+                if let entry = parseServerEntry(name: name, config: config, toolSource: toolSource, configPath: path) {
+                    results.append(entry)
+                }
+            }
+        }
+
+        // Claude Code: also scan per-project mcpServers
+        if toolSource == .claude, let projects = json["projects"] as? [String: [String: Any]] {
+            for (_, projectConfig) in projects {
+                if let servers = projectConfig["mcpServers"] as? [String: [String: Any]] {
+                    for (name, config) in servers {
+                        let existingIDs = Set(results.map(\.id))
+                        let candidateID = MCPServer.makeID(toolSource: toolSource, configFilePath: path, name: name)
+                        guard !existingIDs.contains(candidateID) else { continue }
+                        if let entry = parseServerEntry(name: name, config: config, toolSource: toolSource, configPath: path) {
+                            results.append(entry)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static func parseServerEntry(name: String, config: [String: Any], toolSource: ToolSource, configPath: String) -> ScannedMCPData? {
+        let command = config["command"] as? String
+        let url = config["url"] as? String
+        let args = config["args"] as? [String] ?? []
+        let env = config["env"] as? [String: String] ?? [:]
+        let headers = config["headers"] as? [String: String] ?? [:]
+
+        let transportType: String
+        if url != nil {
+            if let urlStr = url, urlStr.contains("/sse") {
+                transportType = "sse"
+            } else {
+                transportType = "http"
+            }
+        } else if command != nil {
+            transportType = "stdio"
+        } else {
+            return nil
+        }
+
+        let isEnabled = (config["disabled"] as? Bool).map { !$0 } ?? true
+        let id = MCPServer.makeID(toolSource: toolSource, configFilePath: configPath, name: name)
+
+        return ScannedMCPData(
+            id: id,
+            name: name,
+            toolSource: toolSource,
+            configFilePath: configPath,
+            transportType: transportType,
+            command: command,
+            args: args,
+            env: env,
+            url: url,
+            headers: headers,
+            isEnabled: isEnabled
+        )
+    }
+
+    // MARK: - Apply (main thread)
+
+    @MainActor
+    private func applyResults(_ results: [ScannedMCPData]) {
+        let descriptor = FetchDescriptor<MCPServer>()
+        let existing = (try? modelContext.fetch(descriptor)) ?? []
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        let scannedIDs = Set(results.map(\.id))
+
+        for result in results {
+            if let server = existingByID[result.id] {
+                server.name = result.name
+                server.toolSourceRaw = result.toolSource.rawValue
+                server.configFilePath = result.configFilePath
+                server.transportType = result.transportType
+                server.command = result.command
+                server.args = result.args
+                server.env = result.env
+                server.url = result.url
+                server.headers = result.headers
+                server.isEnabled = result.isEnabled
+            } else {
+                let server = MCPServer(
+                    name: result.name,
+                    toolSource: result.toolSource,
+                    configFilePath: result.configFilePath,
+                    transportType: result.transportType,
+                    command: result.command,
+                    args: result.args,
+                    env: result.env,
+                    url: result.url,
+                    headers: result.headers,
+                    isEnabled: result.isEnabled
+                )
+                modelContext.insert(server)
+            }
+        }
+
+        for server in existing where !scannedIDs.contains(server.id) {
+            modelContext.delete(server)
+        }
+
+        do { try modelContext.save() } catch {
+            AppLogger.scanning.error("SwiftData save failed (MCP): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Chops/Views/MCP/MCPDetailView.swift
+++ b/Chops/Views/MCP/MCPDetailView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import SwiftData
+
+struct MCPDetailView: View {
+    @Bindable var server: MCPServer
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                Divider()
+                connectionSection
+                if !server.env.isEmpty {
+                    Divider()
+                    envSection
+                }
+                if !server.headers.isEmpty {
+                    Divider()
+                    headersSection
+                }
+                Divider()
+                sourceSection
+            }
+            .padding(24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .navigationTitle(server.name)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    NSWorkspace.shared.selectFile(
+                        server.configFilePath,
+                        inFileViewerRootedAtPath: ""
+                    )
+                } label: {
+                    Label("Show Config File", systemImage: "doc.text.magnifyingglass")
+                }
+                .help("Reveal config file in Finder")
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 12) {
+            ToolIcon(tool: server.toolSource, size: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(server.name)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                HStack(spacing: 8) {
+                    Text(server.toolSource.displayName)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Text(server.displayTransport)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(transportColor, in: RoundedRectangle(cornerRadius: 4))
+
+                    if !server.isEnabled {
+                        Text("Disabled")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.red, in: RoundedRectangle(cornerRadius: 4))
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var connectionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Connection")
+                .font(.headline)
+
+            if server.transportType == "stdio" {
+                configRow(label: "Command", value: server.command ?? "—")
+                if !server.args.isEmpty {
+                    configRow(label: "Arguments", value: server.args.joined(separator: " "))
+                }
+            } else {
+                configRow(label: "URL", value: server.url ?? "—")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var envSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Environment")
+                .font(.headline)
+
+            ForEach(server.env.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                configRow(label: key, value: maskedValue(value))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var headersSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Headers")
+                .font(.headline)
+
+            ForEach(server.headers.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                configRow(label: key, value: maskedValue(value))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sourceSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Source")
+                .font(.headline)
+
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let displayPath = server.configFilePath.replacingOccurrences(of: home, with: "~")
+            configRow(label: "Config File", value: displayPath)
+        }
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func configRow(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(value)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+                .lineLimit(3)
+        }
+    }
+
+    private var transportColor: Color {
+        switch server.transportType {
+        case "stdio": .blue
+        case "http": .green
+        case "sse": .orange
+        default: .gray
+        }
+    }
+
+    private func maskedValue(_ value: String) -> String {
+        let lowerValue = value.lowercased()
+        let sensitivePatterns = ["key", "token", "secret", "password", "auth", "bearer"]
+        let looksSecret = sensitivePatterns.contains { lowerValue.contains($0) }
+            || (value.count > 20 && !value.contains("/") && !value.contains(" "))
+
+        if looksSecret && value.count > 8 {
+            let prefix = String(value.prefix(4))
+            return "\(prefix)••••••••"
+        }
+        return value
+    }
+}

--- a/Chops/Views/MCP/MCPListView.swift
+++ b/Chops/Views/MCP/MCPListView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import SwiftData
+
+struct MCPListView: View {
+    @Environment(AppState.self) private var appState
+    @Query(sort: \MCPServer.name) private var allServers: [MCPServer]
+
+    private var filteredServers: [MCPServer] {
+        if appState.searchText.isEmpty {
+            return allServers
+        }
+        return allServers.filter {
+            $0.name.localizedCaseInsensitiveContains(appState.searchText) ||
+            $0.toolSource.displayName.localizedCaseInsensitiveContains(appState.searchText) ||
+            ($0.command ?? "").localizedCaseInsensitiveContains(appState.searchText) ||
+            ($0.url ?? "").localizedCaseInsensitiveContains(appState.searchText)
+        }
+    }
+
+    var body: some View {
+        @Bindable var appState = appState
+
+        List(selection: $appState.selectedMCPServer) {
+            ForEach(filteredServers) { server in
+                MCPServerRow(server: server)
+                    .tag(server)
+            }
+        }
+        .navigationTitle("MCP Servers")
+        .overlay {
+            if filteredServers.isEmpty {
+                ContentUnavailableView(
+                    "No MCP Servers",
+                    systemImage: "point.3.connected.trianglepath.dotted",
+                    description: Text("No MCP servers found in your tool configurations.")
+                )
+            }
+        }
+        .onChange(of: appState.sidebarFilter) {
+            if appState.sidebarFilter == .allMCPServers {
+                if let selected = appState.selectedMCPServer, filteredServers.contains(selected) {
+                } else {
+                    appState.selectedMCPServer = filteredServers.first
+                }
+            }
+        }
+        .onAppear {
+            if appState.selectedMCPServer == nil {
+                appState.selectedMCPServer = filteredServers.first
+            }
+        }
+    }
+}
+
+struct MCPServerRow: View {
+    let server: MCPServer
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(server.name)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text(server.displayTransport)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 3))
+
+            ToolIcon(tool: server.toolSource, size: 14)
+                .opacity(0.6)
+                .help(server.toolSource.displayName)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Chops/Views/Sidebar/SidebarView.swift
+++ b/Chops/Views/Sidebar/SidebarView.swift
@@ -6,6 +6,7 @@ struct SidebarView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Skill.name) private var allSkills: [Skill]
     @Query(sort: \RemoteServer.label) private var servers: [RemoteServer]
+    @Query(sort: \MCPServer.name) private var mcpServers: [MCPServer]
     @State private var syncingServerIDs: Set<String> = []
     @State private var serverErrors: [String: String] = [:]
     @State private var showingErrorForServer: String?
@@ -52,6 +53,14 @@ struct SidebarView: View {
                     }
                     .badge(toolCount(tool))
                     .tag(SidebarFilter.tool(tool))
+                }
+            }
+
+            if !mcpServers.isEmpty {
+                Section("MCP") {
+                    Label("All Servers", systemImage: "point.3.connected.trianglepath.dotted")
+                        .badge(mcpServers.count)
+                        .tag(SidebarFilter.allMCPServers)
                 }
             }
 

--- a/Chops/Views/Sidebar/SkillListView.swift
+++ b/Chops/Views/Sidebar/SkillListView.swift
@@ -51,6 +51,8 @@ struct SkillListView: View {
             }
         case .server(let serverID):
             result = result.filter { $0.remoteServer?.id == serverID }
+        case .allMCPServers:
+            return []
         }
 
         if !appState.searchText.isEmpty {
@@ -74,6 +76,8 @@ struct SkillListView: View {
         case .collection(let name): name
         case .server(let id):
             allSkills.first(where: { $0.remoteServer?.id == id })?.remoteServer?.label ?? "Remote"
+        case .allMCPServers:
+            "MCP Servers"
         }
     }
 


### PR DESCRIPTION
File writes from the ACP agent were hitting disk immediately — before the
user could review the diff. Now writes are deferred until Accept is clicked.
In bypass-permissions mode, writes auto-apply and diffs are shown as accepted.
System prompts updated to tell the agent its writes are proposals, not final.