### PR TITLE
feat: expand tool discovery — Cursor/Codex plugins, rules, FNM/Volta/mise binaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,17 @@ SwiftData store path is explicit: `~/Library/Application Support/Chops/Chops.sto
 ## Website
 
 Marketing site lives in `site/` — Astro 6, built with `npm run build` from that directory. Appcast XML is in `site/public/appcast.xml`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues on [Shpigford/chops](https://github.com/Shpigford/chops); use the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles with default label names (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# Chops
+
+A macOS app for discovering, organizing, and editing AI coding agent skills across tools. The domain is the filesystem of agent configuration files and the lifecycle of surfacing them in a unified UI.
+
+## Language
+
+### Discovery
+
+**Skill**: A user-authored AI prompt instruction stored as a file (`SKILL.md`, `.md`, `.mdc`, `.toml`, or `.rules`) and discoverable by scanning tool directories. The atomic unit Chops manages.
+_Avoid_: Prompt, instruction, command
+
+**Agent**: A sub-agent definition file scanned from an `agents/` directory. Represents a named autonomous persona a tool can spawn to handle delegated tasks.
+_Avoid_: Sub-agent file, agent config
+
+**Rule**: A persistent instruction applied to every session of a tool, scanned from a `rules/` directory. Includes Cursor `.mdc` rules and Codex `.rules` files.
+_Avoid_: Global prompt, persistent instruction
+
+**Plugin**: A packaged collection of skills/agents/rules distributed via a marketplace and cached locally by the tool. Plugin skills are read-only (the cache is tool-managed). Distinct from user-authored skills in the global skills directory.
+_Avoid_: Extension, package
+
+**ToolSource**: An enum case identifying the coding agent tool that owns or uses a discoverable item (e.g. `.claude`, `.cursor`, `.codex`). Also determines which filesystem paths to scan.
+_Avoid_: Tool, provider, agent (overloaded)
+
+**ItemKind**: The discriminant (`skill | agent | rule`) classifying a single discovered item. Determines which sidebar section the item appears in and which icon/label is used.
+_Avoid_: Type, category, kind (unqualified)
+
+### Identity
+
+**resolvedPath**: The canonical, stable identity of a discovered item. For filesystem items, this is the symlink-resolved absolute path. For plugin items, it is a synthetic URI (`claude-plugin:`, `cursor-plugin:`, `codex-plugin:`) with the volatile component (version hash) stripped out, so updates do not produce duplicate entries.
+_Avoid_: File path, canonical path
+
+**installedPaths**: The set of raw filesystem paths where a skill is physically present (e.g. both `~/.claude/skills/foo/SKILL.md` and `~/.cursor/skills/foo/SKILL.md` for a symlinked skill). Multiple paths collapse to one skill entry via the shared `resolvedPath`.
+_Avoid_: Locations, copies
+
+**isGlobal**: Whether a skill was found in a tool's global (home-directory) skills directory, as opposed to a project-local directory (e.g. `.claude/skills/` inside a repo).
+_Avoid_: Global flag, scope
+
+### Scanning
+
+**SkillScanner**: The service that walks the filesystem, parses frontmatter, and upserts discovered items into SwiftData. Runs off the main thread; results are applied on the main actor.
+
+**projectProbe**: A (subpath, tool, kind) triple used to locate tool-specific directories inside a project directory during custom-path scanning (e.g. `.cursor/rules` → Cursor rule).
+_Avoid_: Project path, repo probe
+
+**includePlugins**: A user preference controlling whether plugin caches are scanned. Off by default to avoid surfacing hundreds of read-only skills from installed plugin packages.

--- a/Chops/Models/Skill.swift
+++ b/Chops/Models/Skill.swift
@@ -37,7 +37,9 @@ extension Skill {
     var isPlugin: Bool {
         filePath.contains("/.claude/plugins/") ||
         filePath.contains("/local-agent-mode-sessions/") ||
-        toolSources.contains(.claudeDesktop)
+        toolSources.contains(.claudeDesktop) ||
+        resolvedPath.hasPrefix("cursor-plugin:") ||
+        resolvedPath.hasPrefix("codex-plugin:")
     }
 
     var isReadOnly: Bool {

--- a/Chops/Models/ToolSource.swift
+++ b/Chops/Models/ToolSource.swift
@@ -132,7 +132,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .augment: return ["\(home)/.augment/skills"]
         case .claude: return ["\(home)/.claude/skills"]
-        case .cursor: return ["\(home)/.cursor/skills"]
+        case .cursor: return ["\(home)/.cursor/skills", "\(home)/.cursor/skills-cursor"]
         case .windsurf: return []
         case .codex: return ["\(home)/.codex/skills"]
         case .copilot: return ["\(home)/.copilot/skills"]
@@ -187,6 +187,7 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         switch self {
         case .cursor: return ["\(home)/.cursor/rules"]
+        case .codex: return ["\(home)/.codex/rules"]
         case .windsurf: return ["\(home)/.codeium/windsurf/memories", "\(home)/.windsurf/rules"]
         default: return []
         }
@@ -212,7 +213,8 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
             return fm.fileExists(atPath: "/Applications/Windsurf.app")
                 || fm.fileExists(atPath: "\(home)/.codeium/windsurf/argv.json")
         case .codex:
-            return fm.fileExists(atPath: "\(home)/.codex/config.toml")
+            return Self.appBundleExists("Codex")
+                || fm.fileExists(atPath: "\(home)/.codex/config.toml")
                 || fm.fileExists(atPath: "\(home)/.codex/auth.json")
                 || Self.cliBinaryExists("codex")
         case .amp:
@@ -283,14 +285,36 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
             "\(home)/.local/bin/\(name)",
             "/opt/homebrew/bin/\(name)",
             "/usr/local/bin/\(name)",
+            "\(home)/.volta/bin/\(name)",
         ])
         for path in paths where fm.isExecutableFile(atPath: path) {
             return URL(fileURLWithPath: path)
         }
+        // NVM: ~/.nvm/versions/node/<version>/bin/<name>
         let nvmDir = "\(home)/.nvm/versions/node"
         if let nodeDirs = try? fm.contentsOfDirectory(atPath: nvmDir) {
             for nodeDir in nodeDirs.sorted().reversed() {
                 let candidate = "\(nvmDir)/\(nodeDir)/bin/\(name)"
+                if fm.isExecutableFile(atPath: candidate) {
+                    return URL(fileURLWithPath: candidate)
+                }
+            }
+        }
+        // FNM: ~/.local/share/fnm/node-versions/<version>/installation/bin/<name>
+        let fnmDir = "\(home)/.local/share/fnm/node-versions"
+        if let nodeDirs = try? fm.contentsOfDirectory(atPath: fnmDir) {
+            for nodeDir in nodeDirs.sorted().reversed() {
+                let candidate = "\(fnmDir)/\(nodeDir)/installation/bin/\(name)"
+                if fm.isExecutableFile(atPath: candidate) {
+                    return URL(fileURLWithPath: candidate)
+                }
+            }
+        }
+        // mise: ~/.local/share/mise/installs/node/<version>/bin/<name>
+        let miseDir = "\(home)/.local/share/mise/installs/node"
+        if let nodeDirs = try? fm.contentsOfDirectory(atPath: miseDir) {
+            for nodeDir in nodeDirs.sorted().reversed() {
+                let candidate = "\(miseDir)/\(nodeDir)/bin/\(name)"
                 if fm.isExecutableFile(atPath: candidate) {
                     return URL(fileURLWithPath: candidate)
                 }
@@ -307,7 +331,10 @@ enum ToolSource: String, Codable, CaseIterable, Identifiable {
         case .claude:
             return Self.cliBinaryURL("claude")
         case .codex:
-            return Self.cliBinaryURL("codex", extraPaths: ["\(home)/.codex/bin/codex"])
+            return Self.cliBinaryURL("codex", extraPaths: [
+                "\(home)/.codex/bin/codex",
+                "/Applications/Codex.app/Contents/Resources/codex",
+            ])
         default:
             return nil
         }

--- a/Chops/Services/SkillScanner.swift
+++ b/Chops/Services/SkillScanner.swift
@@ -120,6 +120,14 @@ final class SkillScanner {
             if ToolSource.claudeDesktop.isInstalled {
                 collectClaudeDesktopSkills(into: &results)
             }
+            // Cursor plugin cache
+            if ToolSource.cursor.isInstalled {
+                collectFromCursorPlugins(into: &results)
+            }
+            // Codex plugin cache
+            if ToolSource.codex.isInstalled {
+                collectFromCodexPlugins(into: &results)
+            }
         }
 
         for path in customPaths {
@@ -199,7 +207,7 @@ final class SkillScanner {
                     results.append(data)
                 }
             } else {
-                guard ["md", "mdc", "toml"].contains(item.pathExtension) else { continue }
+                guard ["md", "mdc", "toml", "rules"].contains(item.pathExtension) else { continue }
                 guard !shouldIgnoreLooseMarkdownFile(named: item.lastPathComponent) else { continue }
                 if let data = collectSkillData(
                     at: item,
@@ -271,7 +279,7 @@ final class SkillScanner {
                     // Hermes nests skills as ~/.hermes/skills/<category>/<skill>/SKILL.md (agentskills.io layout).
                     collectFromDirectory(item, toolSource: toolSource, isGlobal: isGlobal, kind: kind, into: &results)
                 }
-            } else if item.pathExtension == "md" || item.pathExtension == "mdc" || item.pathExtension == "toml" {
+            } else if ["md", "mdc", "toml", "rules"].contains(item.pathExtension) {
                 guard !shouldIgnoreLooseMarkdownFile(named: item.lastPathComponent) else { continue }
                 if let data = collectSkillData(at: item, toolSource: toolSource, isDirectory: false, isGlobal: isGlobal, kind: kind) {
                     results.append(data)
@@ -292,7 +300,7 @@ final class SkillScanner {
             var isDir: ObjCBool = false
             fm.fileExists(atPath: item.path, isDirectory: &isDir)
             guard !isDir.boolValue else { return false }
-            guard ["md", "mdc", "toml"].contains(item.pathExtension) else { return false }
+            guard ["md", "mdc", "toml", "rules"].contains(item.pathExtension) else { return false }
             return !shouldIgnoreLooseMarkdownFile(named: item.lastPathComponent)
         }
 
@@ -324,6 +332,24 @@ final class SkillScanner {
             return "claude-plugin:\(parts[0])/\(parts[1])/\(parts[4])"
         }
 
+        // Cursor plugins: .../.cursor/plugins/cache/<publisher>/<plugin>/<hash>/.cursor/skills/<skill>/SKILL.md
+        if toolSource == .cursor, let range = path.range(of: ".cursor/plugins/cache/") {
+            let after = String(path[range.upperBound...])
+            let parts = after.components(separatedBy: "/")
+            // parts: [publisher, plugin, hash, ".cursor", "skills", skill, "SKILL.md"]
+            guard parts.count >= 7, parts[3] == ".cursor", parts[4] == "skills" else { return resolved }
+            return "cursor-plugin:\(parts[0])/\(parts[1])/\(parts[5])"
+        }
+
+        // Codex plugins: .../.codex/plugins/cache/<namespace>/<plugin>/<version>/skills/<skill>/SKILL.md
+        if toolSource == .codex, let range = path.range(of: ".codex/plugins/cache/") {
+            let after = String(path[range.upperBound...])
+            let parts = after.components(separatedBy: "/")
+            // parts: [namespace, plugin, version, "skills", skill, "SKILL.md"]
+            guard parts.count >= 6, parts[3] == "skills" else { return resolved }
+            return "codex-plugin:\(parts[0])/\(parts[1])/\(parts[4])"
+        }
+
         guard toolSource == .claudeDesktop else { return resolved }
 
         // Local plugins: .../cowork_plugins/cache/<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md
@@ -348,7 +374,10 @@ final class SkillScanner {
     }
 
     private static func isSyntheticLocalResolvedPath(_ resolvedPath: String) -> Bool {
-        resolvedPath.hasPrefix("claude-plugin:") || resolvedPath.hasPrefix("claude-desktop:")
+        resolvedPath.hasPrefix("claude-plugin:") ||
+        resolvedPath.hasPrefix("claude-desktop:") ||
+        resolvedPath.hasPrefix("cursor-plugin:") ||
+        resolvedPath.hasPrefix("codex-plugin:")
     }
 
     /// Read and parse a single skill file. Pure I/O, no SwiftData.
@@ -411,6 +440,63 @@ final class SkillScanner {
                 guard let installPath = installation["installPath"] as? String else { continue }
                 let skillsDir = URL(fileURLWithPath: installPath).appendingPathComponent("skills")
                 collectFromDirectory(skillsDir, toolSource: .claude, isGlobal: true, into: &results)
+            }
+        }
+    }
+
+    /// Scan Cursor plugin cache: ~/.cursor/plugins/cache/{publisher}/{plugin}/{hash}/.cursor/skills/
+    private static func collectFromCursorPlugins(into results: inout [ScannedSkillData]) {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let cacheRoot = "\(home)/.cursor/plugins/cache"
+
+        guard let publishers = try? fm.contentsOfDirectory(atPath: cacheRoot) else { return }
+
+        for publisher in publishers {
+            guard !Task.isCancelled else { return }
+            let publisherPath = "\(cacheRoot)/\(publisher)"
+            guard let plugins = try? fm.contentsOfDirectory(atPath: publisherPath) else { continue }
+
+            for plugin in plugins {
+                guard !Task.isCancelled else { return }
+                let pluginPath = "\(publisherPath)/\(plugin)"
+                guard let hashes = try? fm.contentsOfDirectory(atPath: pluginPath) else { continue }
+
+                for hash in hashes {
+                    guard !Task.isCancelled else { return }
+                    let skillsDir = URL(fileURLWithPath: "\(pluginPath)/\(hash)/.cursor/skills")
+                    collectFromDirectory(skillsDir, toolSource: .cursor, isGlobal: true, into: &results)
+                }
+            }
+        }
+    }
+
+    /// Scan Codex plugin cache: ~/.codex/plugins/cache/{namespace}/{plugin}/{version}/skills/
+    /// Skips openai-primary-runtime (built-in Codex runtime capabilities, not user-facing skills).
+    private static func collectFromCodexPlugins(into results: inout [ScannedSkillData]) {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let cacheRoot = "\(home)/.codex/plugins/cache"
+
+        guard let namespaces = try? fm.contentsOfDirectory(atPath: cacheRoot) else { return }
+
+        for namespace in namespaces {
+            guard !Task.isCancelled else { return }
+            if namespace == "openai-primary-runtime" { continue }
+
+            let namespacePath = "\(cacheRoot)/\(namespace)"
+            guard let plugins = try? fm.contentsOfDirectory(atPath: namespacePath) else { continue }
+
+            for plugin in plugins {
+                guard !Task.isCancelled else { return }
+                let pluginPath = "\(namespacePath)/\(plugin)"
+                guard let versions = try? fm.contentsOfDirectory(atPath: pluginPath) else { continue }
+
+                for version in versions {
+                    guard !Task.isCancelled else { return }
+                    let skillsDir = URL(fileURLWithPath: "\(pluginPath)/\(version)/skills")
+                    collectFromDirectory(skillsDir, toolSource: .codex, isGlobal: true, into: &results)
+                }
             }
         }
     }

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,42 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   ├── adr/
+│   │   ├── 0001-swiftdata-schema-versioning.md
+│   │   └── 0002-one-shot-agent-transports.md
+│   └── agents/
+│       ├── issue-tracker.md
+│       ├── triage-labels.md
+│       └── domain.md
+├── Chops/
+├── site/
+└── CLAUDE.md
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on [Shpigford/chops](https://github.com/Shpigford/chops). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone of `Shpigford/chops`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

- **Cursor `skills-cursor` path**: `~/.cursor/skills-cursor` (the Cursor app's default global skills directory) was not being scanned. Added it to Cursor's `globalPaths` alongside `~/.cursor/skills`.
- **Codex rules**: Added `~/.codex/rules` to Codex's `globalRulePaths` and extended the file extension filter to include `.rules` files (e.g. `default.rules`).
- **Cursor plugin skills**: Scanner now reads `~/.cursor/plugins/cache/{publisher}/{plugin}/{hash}/.cursor/skills/` and uses `cursor-plugin:` canonical IDs (hash stripped) so updates don't produce duplicates.
- **Codex plugin skills**: Scanner now reads `~/.codex/plugins/cache/` across `openai-bundled`, `openai-curated`, and `openai-curated-remote` namespaces. `openai-primary-runtime` is skipped (built-in runtime, not user-facing skills). Uses `codex-plugin:` canonical IDs.
- Both new plugin scanners are gated behind the existing `includePlugins` preference.
- **Codex.app detection**: `isInstalled` for Codex now checks `/Applications/Codex.app`; `cliBinaryURL` probes the app-bundle binary at `Contents/Resources/codex`.
- **FNM / Volta / mise support**: `cliBinaryURL` now probes `~/.local/share/fnm/node-versions/`, `~/.volta/bin/`, and `~/.local/share/mise/installs/node/` in addition to NVM — fixes "Claude Code isn't installed" on machines that manage Node via FNM.
- **`CONTEXT.md`**: New domain glossary (Skill, Agent, Rule, Plugin, ToolSource, ItemKind, resolvedPath, etc.) for agents working in this repo.
- **Agent docs**: `docs/agents/` with issue-tracker, triage-labels, and domain-model conventions.

## Test plan

- [ ] Build succeeds (`xcodebuild -scheme Chops -configuration Debug`)
- [ ] Launch app — Cursor appears in the Tools sidebar with skills from `~/.cursor/skills-cursor`
- [ ] Toggle "Include plugin skills" on — Cursor and Codex plugin skills appear
- [ ] Codex rule file (`~/.codex/rules/default.rules`) appears under Rules
- [ ] Agent Settings panel shows Claude Code as installed (on FNM machines)
- [ ] Agent Settings panel shows Codex as installed when `Codex.app` is present